### PR TITLE
Fix/mission error

### DIFF
--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
@@ -72,7 +72,7 @@ fun NavController.navigateToBoardDetail(
 }
 
 fun NavGraphBuilder.boardDetailNavGraph(
-    onDelete: () -> Unit,
+    onNavigateOnboarding: () -> Unit,
     onBackClick: () -> Unit
 ) {
     composable(
@@ -80,7 +80,7 @@ fun NavGraphBuilder.boardDetailNavGraph(
         arguments = listOf(navArgument(missionIdArg) { type = NavType.LongType })
     ) {
         BoardMissionDetailRoute(
-            onDelete = onDelete,
+            onNavigateOnboarding = onNavigateOnboarding,
             onBackClick = onBackClick
         )
     }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
@@ -94,10 +94,7 @@ fun UserStoryItem(
                 .height(64.dp)
                 .width(64.dp)
                 .then(
-                    if(missionState.isEnabledToInvite() && userStory.isMe){
-                        Modifier .border(3.dp, ColorWhite_FFFFFFFF, CircleShape)
-                    }
-                    else if (userStory.isVerified) {
+                    if (userStory.isVerified) {
                         Modifier
                             .border(3.dp, OrangeGradient_FFFF5F3C_FFFFAE50, CircleShape)
                             .clickable(
@@ -108,7 +105,7 @@ fun UserStoryItem(
                     } else {
                         Modifier
                             .border(3.dp, ColorWhite_FFFFFFFF, CircleShape)
-                            .alpha(0.5f)
+                            .alpha(if(userStory.isMe) 1f else 0.5f)
                     }
                 )
                 .paint(

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
@@ -83,7 +83,7 @@ fun UserStoryItem(
     Box(
         modifier = modifier
             .height(98.dp)
-            .width(70.dp),
+            .widthIn(min = 70.dp),
         contentAlignment = Alignment.TopCenter
     ) {
         Image(
@@ -140,10 +140,10 @@ fun UserStoryItem(
                 )
                 .border(
                     1.dp,
-                    color = ColorGray5_FFF5F6F9.copy(alpha = 0.5f),
+                    color = ColorWhite_FFFFFFFF.copy(alpha = 0.75f),
                     shape = RoundedCornerShape(20.dp)
                 )
-                .padding(vertical = 1.dp, horizontal = 4.dp)
+                .padding(vertical = 1.dp, horizontal = 5.dp)
                 .align(Alignment.BottomCenter),
             text = userStory.nickname,
             textAlign = TextAlign.Center,
@@ -151,19 +151,6 @@ fun UserStoryItem(
             style = MissionMateTypography.body_sm_regular
 
         )
-//        Box(
-//            modifier = modifier
-//                .size(64.dp)
-//                .paint(
-//                    painter = painterResource(id = R.drawable.img_sea)
-//                )
-//                //.background(color = userStory.characterType.color, shape = CircleShape)
-//                //.border(1.dp, color = if(userStory.isVerified)  )
-//                // .align(Alignment.CenterHorizontally)
-//        ) {
-//         //   CharacterLargeImage(imageResId = it.imageResId)
-//        }
-        //  StableImage(drawableResId = )
     }
 }
 

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/Piece.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/Piece.kt
@@ -128,7 +128,8 @@ fun PieceNameChip(
 ){
     Text(
         modifier = modifier
-            .widthIn(min = 90.dp)
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth()
             .wrapContentHeight()
             .clip(RoundedCornerShape(20.dp))
             .background(

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/MissionError.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/MissionError.kt
@@ -1,0 +1,5 @@
+package com.goalpanzi.mission_mate.feature.board.model
+
+enum class MissionError {
+    NOT_EXIST,
+}

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardDetailViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardDetailViewModel.kt
@@ -7,6 +7,7 @@ import com.goalpanzi.core.model.base.NetworkResult
 import com.goalpanzi.mission_mate.core.domain.usecase.DeleteMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.usecase.GetCachedMemberIdUseCase
 import com.goalpanzi.mission_mate.core.domain.usecase.GetMissionUseCase
+import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.toModel
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -40,6 +41,9 @@ class BoardDetailViewModel @Inject constructor(
         initialValue = null
     )
 
+    private val _missionError = MutableSharedFlow<MissionError>()
+    val missionError : SharedFlow<MissionError> =_missionError.asSharedFlow()
+
     private val _deleteMissionResultEvent = MutableSharedFlow<Boolean>()
     val deleteMissionResultEvent: SharedFlow<Boolean> = _deleteMissionResultEvent.asSharedFlow()
 
@@ -72,6 +76,7 @@ class BoardDetailViewModel @Inject constructor(
 
                     else -> {
                         _missionUiModel.emit(MissionUiModel.Error)
+                        _missionError.emit(MissionError.NOT_EXIST)
                     }
                 }
             }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardMissionDetailScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardMissionDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.goalpanzi.mission_mate.feature.board.screen
 
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -26,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -51,11 +53,12 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun BoardMissionDetailRoute(
-    onDelete : () -> Unit,
+    onNavigateOnboarding : () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: BoardDetailViewModel = hiltViewModel()
 ) {
+    val context = LocalContext.current
     val missionUiModel by viewModel.missionUiModel.collectAsStateWithLifecycle()
     val isHost by viewModel.isHost.collectAsStateWithLifecycle()
     var isShownRequestDeleteMissionDialog by remember { mutableStateOf(false) }
@@ -67,8 +70,15 @@ fun BoardMissionDetailRoute(
             viewModel.deleteMissionResultEvent.collect {
                 if (it) {
                     isShownRequestDeleteMissionDialog = false
-                    onDelete()
+                    onNavigateOnboarding()
                 }
+            }
+        }
+
+        launch {
+            viewModel.missionError.collect {
+                Toast.makeText(context,context.getString(R.string.board_mission_not_exist),Toast.LENGTH_SHORT).show()
+                onNavigateOnboarding()
             }
         }
 
@@ -267,7 +277,7 @@ fun BoardMissionDetailScreen(
 private fun PreviewBoardMissionDetailRoute() {
     BoardMissionDetailRoute(
         onBackClick = {},
-        onDelete = {}
+        onNavigateOnboarding = {}
     )
 
 }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
@@ -274,7 +274,7 @@ fun BoardScreen(
                     modifier = Modifier
                         .wrapContentSize()
                         .padding(
-                            top = 180.dp,
+                            top = 195.dp,
                             bottom = if (missionState.isVisiblePiece()) 188.dp else 46.dp
                         )
                         .align(Alignment.Center),
@@ -300,7 +300,7 @@ fun BoardScreen(
                     StableImage(
                         missionVerificationUiModel.missionVerificationsResponse.missionVerifications.first().characterType.toCharacter().imageId,
                         modifier = Modifier
-                            .padding(top = 85.dp)
+                            .padding(top = 75.dp)
                             .fillMaxWidth(240f / 390f)
                             .aspectRatio(1f)
                     )

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
@@ -2,6 +2,7 @@ package com.goalpanzi.mission_mate.feature.board.screen
 
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -116,6 +117,15 @@ fun BoardRoute(
                 onClickStory(it)
             }
         }
+        launch {
+            viewModel.missionError.collect {
+                if(it != null){
+                    Toast.makeText(context,context.getString(R.string.board_mission_not_exist), Toast.LENGTH_SHORT).show()
+                    onNavigateOnboarding()
+                    return@collect
+                }
+            }
+        }
     }
 
     LaunchedEffect(missionState) {
@@ -195,6 +205,7 @@ fun BoardRoute(
             viewModel.getMyMissionVerification(it)
         }
     )
+
 }
 
 @Composable

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -17,6 +17,7 @@ import com.goalpanzi.mission_mate.core.domain.usecase.SetViewedTooltipUseCase
 import com.goalpanzi.mission_mate.core.domain.usecase.VerifyMissionUseCase
 import com.goalpanzi.mission_mate.feature.board.model.BoardPiece
 import com.goalpanzi.mission_mate.feature.board.model.BoardPieceType
+import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.MissionState
 import com.goalpanzi.mission_mate.feature.board.model.MissionState.Companion.getMissionState
 import com.goalpanzi.mission_mate.feature.board.model.UserStory
@@ -65,6 +66,9 @@ class BoardViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(500),
         initialValue = true
     )
+
+    private val _missionError = MutableStateFlow<MissionError?>(null)
+    val missionError : StateFlow<MissionError?> =_missionError.asStateFlow()
 
     private val _myMissionVerification = MutableSharedFlow<UserStory>()
     val myMissionVerification : SharedFlow<UserStory> = _myMissionVerification.asSharedFlow()
@@ -139,6 +143,7 @@ class BoardViewModel @Inject constructor(
 
                         else -> {
                             _missionBoardUiModel.emit(MissionBoardUiModel.Error)
+                            _missionError.emit(MissionError.NOT_EXIST)
                         }
                     }
                 }
@@ -157,6 +162,7 @@ class BoardViewModel @Inject constructor(
 
                     else -> {
                         _missionUiModel.emit(MissionUiModel.Error)
+                        _missionError.emit(MissionError.NOT_EXIST)
                     }
                 }
             }
@@ -175,6 +181,7 @@ class BoardViewModel @Inject constructor(
 
                     else -> {
                         _missionVerificationUiModel.emit(MissionVerificationUiModel.Error)
+                        _missionError.emit(MissionError.NOT_EXIST)
                     }
                 }
             }

--- a/feature/board/src/main/res/values/strings.xml
+++ b/feature/board/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="board_mission_detail_description_color_target">인증횟수(보드판 수)는 총 %d개</string>
     <string name="board_mission_detail_delete">삭제하기</string>
 
+    <string name="board_mission_not_exist">미션을 불러올 수 없습니다.</string>
+
     <string name="ok">확인</string>
     <string name="cancel">취소</string>
     <string name="close">닫기</string>

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/core/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/core/main/component/MainNavHost.kt
@@ -109,7 +109,7 @@ internal fun MainNavHost(
                 }
             )
             boardDetailNavGraph(
-                onDelete = {
+                onNavigateOnboarding = {
                     navigator.navigationToOnboarding()
                 },
                 onBackClick = {

--- a/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/screen/invitation/InvitationCodeViewModel.kt
+++ b/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/screen/invitation/InvitationCodeViewModel.kt
@@ -43,25 +43,25 @@ class InvitationCodeViewModel @Inject constructor(
     var codeFirst by mutableStateOf("")
         private set
 
-    private val isNotCodeFirstEmpty =
+    private val codeFirstFlow =
         snapshotFlow { codeFirst }
 
     var codeSecond by mutableStateOf("")
         private set
 
-    private val isNotCodeSecondEmpty =
+    private val codeSecondFlow =
         snapshotFlow { codeSecond }
 
     var codeThird by mutableStateOf("")
         private set
 
-    private val isNotCodeThirdEmpty =
+    private val codeThirdFlow =
         snapshotFlow { codeThird }
 
     var codeFourth by mutableStateOf("")
         private set
 
-    private val isNotCodeFourthEmpty =
+    private val codeFourthFlow =
         snapshotFlow { codeFourth }
 
     private val _isNotCodeValid = MutableStateFlow(false)
@@ -72,10 +72,10 @@ class InvitationCodeViewModel @Inject constructor(
 
     val enabledButton: StateFlow<Boolean> =
         combine(
-            isNotCodeFirstEmpty.map { it.isNotEmpty() },
-            isNotCodeSecondEmpty.map { it.isNotEmpty() },
-            isNotCodeThirdEmpty.map { it.isNotEmpty() },
-            isNotCodeFourthEmpty.map { it.isNotEmpty() },
+            codeFirstFlow.map { it.isNotEmpty() },
+            codeSecondFlow.map { it.isNotEmpty() },
+            codeThirdFlow.map { it.isNotEmpty() },
+            codeFourthFlow.map { it.isNotEmpty() },
             isNotCodeValid
         ) { isNotFirstEmpty, isNotSecondEmpty, isNotThirdEmpty, isNotFourthEmpty, isNotValid ->
             isNotFirstEmpty && isNotSecondEmpty && isNotThirdEmpty && isNotFourthEmpty && !isNotValid
@@ -85,15 +85,8 @@ class InvitationCodeViewModel @Inject constructor(
             initialValue = false
         )
 
-    val codeInputActionEvent: SharedFlow<CodeActionEvent> =
-        merge(
-            isNotCodeFirstEmpty.filterNot { it.isEmpty() }.map { CodeActionEvent.FIRST_DONE },
-            isNotCodeSecondEmpty.filterNot { it.isEmpty() }.map { CodeActionEvent.SECOND_DONE },
-            isNotCodeThirdEmpty.filterNot { it.isEmpty() }.map { CodeActionEvent.THIRD_DONE }
-        ).shareIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(500)
-        )
+    private val _codeInputActionEvent = MutableSharedFlow<CodeActionEvent>()
+    val codeInputActionEvent: SharedFlow<CodeActionEvent> = _codeInputActionEvent.asSharedFlow()
 
     private val _codeResultEvent = MutableSharedFlow<CodeResultEvent>()
     val codeResultEvent: SharedFlow<CodeResultEvent> = _codeResultEvent.asSharedFlow()
@@ -102,23 +95,39 @@ class InvitationCodeViewModel @Inject constructor(
     val joinResultEvent: SharedFlow<JoinResultEvent> = _joinResultEvent.asSharedFlow()
 
     fun updateCodeFirst(code: String) {
+        if(code == " ") return
         if (isNotCodeValid.value) resetCodeValidState()
         if (code.length <= 1) codeFirst = code
+        viewModelScope.launch {
+            _codeInputActionEvent.emit(if(code.isNotEmpty()) CodeActionEvent.FIRST_DONE  else CodeActionEvent.FIRST_CLEAR)
+        }
     }
 
     fun updateCodeSecond(code: String) {
+        if(code == " ") return
         if (isNotCodeValid.value) resetCodeValidState()
         if (code.length <= 1) codeSecond = code
+        viewModelScope.launch {
+            _codeInputActionEvent.emit(if(code.isNotEmpty()) CodeActionEvent.SECOND_DONE  else CodeActionEvent.SECOND_CLEAR)
+        }
     }
 
     fun updateCodeThird(code: String) {
+        if(code == " ") return
         if (isNotCodeValid.value) resetCodeValidState()
         if (code.length <= 1) codeThird = code
+        viewModelScope.launch {
+            _codeInputActionEvent.emit(if(code.isNotEmpty()) CodeActionEvent.THIRD_DONE  else CodeActionEvent.THIRD_CLEAR)
+        }
     }
 
     fun updateCodeFourth(code: String) {
+        if(code == " ") return
         if (isNotCodeValid.value) resetCodeValidState()
         if (code.length <= 1) codeFourth = code
+        viewModelScope.launch {
+            _codeInputActionEvent.emit(if(code.isNotEmpty()) CodeActionEvent.FOURTH_DONE else CodeActionEvent.FOURTH_CLEAR)
+        }
     }
 
     fun checkCode() {

--- a/feature/onboarding/src/main/res/values/strings.xml
+++ b/feature/onboarding/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="onboarding_board_setup_verification_time_input_title">인증 시간</string>
     <string name="onboarding_board_setup_verification_time_input_content_am">오전\n00~12시</string>
     <string name="onboarding_board_setup_verification_time_input_content_pm">오후\n12~00시</string>
-    <string name="onboarding_board_setup_verification_time_input_content_all">종일\n00~00시</string>
+    <string name="onboarding_board_setup_verification_time_input_content_all">종일\n00~24시</string>
 
     <string name="onboarding_board_setup_success_title">미션설정 완료!\n이제 시작해볼까요?</string>
     <string name="onboarding_board_setup_success_description">친구와 함께 꾸준히 미션을 완수해\n세계 곳곳을 경험해봐요!</string>

--- a/feature/profile/src/main/java/com/goalpanzi/mission_mate/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/goalpanzi/mission_mate/feature/profile/ProfileScreen.kt
@@ -63,6 +63,7 @@ import com.goalpanzi.mission_mate.core.designsystem.theme.MissionMateTypography
 import com.goalpanzi.mission_mate.core.designsystem.theme.component.MissionMateTopAppBar
 import com.goalpanzi.mission_mate.core.designsystem.theme.component.NavigationType
 import com.goalpanzi.mission_mate.feature.profile.model.CharacterListItem
+import com.goalpanzi.mission_mate.feature.profile.model.CharacterListItem.Companion.createDefaultList
 import com.goalpanzi.mission_mate.feature.profile.model.ProfileUiState
 import com.luckyoct.feature.profile.R
 import dagger.hilt.android.EntryPointAccessors
@@ -233,7 +234,7 @@ fun ColumnScope.ProfileScreen(
                     .align(Alignment.CenterHorizontally)
             ) {
                 CharacterLargeImage(
-                    imageResId = it.imageResId,
+                    imageResId = it.defaultImageResId,
                     backgroundResId = it.backgroundResId
                 )
             }
@@ -299,7 +300,7 @@ fun CharacterLargeImage(
             .paint(
                 painter = painterResource(backgroundResId),
                 contentScale = ContentScale.FillWidth,
-            )
+            ).padding(20.dp)
     )
 }
 
@@ -325,7 +326,7 @@ fun CharacterRow(
         contentPadding = PaddingValues(horizontal = 24.dp),
         state = scrollState
     ) {
-        items(items = characters, key = { it.imageResId }) {
+        items(items = characters, key = { it.selectedImageResId }) {
             CharacterElement(
                 character = it,
                 configuration = configuration,
@@ -356,7 +357,7 @@ fun CharacterElement(
             )
     ) {
         Image(
-            painter = painterResource(id = character.imageResId),
+            painter = painterResource(id = character.selectedImageResId),
             contentDescription = null,
         )
 
@@ -386,36 +387,7 @@ fun ColumnScope.ProfileScreenPreview() {
     ProfileScreen(
         profileSettingType = ProfileSettingType.CREATE,
         initialNickname = "",
-        characters = listOf(
-            CharacterListItem(
-                type = CharacterType.RABBIT,
-                imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_rabbit_selected,
-                nameResId = R.string.rabbit_name,
-                isSelected = true,
-                backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_rabbit
-            ),
-            CharacterListItem(
-                type = CharacterType.CAT,
-                imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_cat_selected,
-                nameResId = R.string.cat_name,
-                isSelected = false,
-                backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_cat
-            ),
-            CharacterListItem(
-                type = CharacterType.DOG,
-                imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_dog_selected,
-                nameResId = R.string.dog_name,
-                isSelected = false,
-                backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_dog
-            ),
-            CharacterListItem(
-                type = CharacterType.PANDA,
-                imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_panda_selected,
-                nameResId = R.string.panda_name,
-                isSelected = false,
-                backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_panda
-            ),
-        ),
+        characters = createDefaultList(),
         onClickCharacter = {},
         onClickSave = {},
         isNicknameDuplicated = false,
@@ -429,7 +401,8 @@ fun CharacterElementPreview() {
     CharacterElement(
         character = CharacterListItem(
             type = CharacterType.CAT,
-            imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_cat_selected,
+            selectedImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_cat_selected,
+            defaultImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_cat_default,
             nameResId = R.string.cat_name,
             isSelected = false,
             backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_cat

--- a/feature/profile/src/main/java/com/goalpanzi/mission_mate/feature/profile/model/CharacterListItem.kt
+++ b/feature/profile/src/main/java/com/goalpanzi/mission_mate/feature/profile/model/CharacterListItem.kt
@@ -7,7 +7,8 @@ import com.luckyoct.feature.profile.R
 
 data class CharacterListItem(
     val type: CharacterType,
-    @DrawableRes val imageResId: Int,
+    @DrawableRes val selectedImageResId: Int,
+    @DrawableRes val defaultImageResId: Int,
     @StringRes val nameResId: Int,
     val isSelected: Boolean = false,
     @DrawableRes val backgroundResId: Int
@@ -16,37 +17,43 @@ data class CharacterListItem(
         fun createDefaultList() = listOf(
             CharacterListItem(
                 type = CharacterType.RABBIT,
-                imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_rabbit_selected,
+                selectedImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_rabbit_selected,
+                defaultImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_rabbit_default,
                 nameResId = R.string.rabbit_name,
                 backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_rabbit
             ),
             CharacterListItem(
                 type = CharacterType.CAT,
-                imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_cat_selected,
+                selectedImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_cat_selected,
+                defaultImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_cat_default,
                 nameResId = R.string.cat_name,
                 backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_cat
             ),
             CharacterListItem(
                 type = CharacterType.DOG,
-                imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_dog_selected,
+                selectedImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_dog_selected,
+                defaultImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_dog_default,
                 nameResId = R.string.dog_name,
                 backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_dog
             ),
             CharacterListItem(
                 type = CharacterType.PANDA,
-                imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_panda_selected,
+                selectedImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_panda_selected,
+                defaultImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_panda_default,
                 nameResId = R.string.panda_name,
                 backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_panda
             ),
             CharacterListItem(
                 type = CharacterType.BEAR,
-                imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_bear_selected,
+                selectedImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_bear_selected,
+                defaultImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_bear_default,
                 nameResId = R.string.bear_name,
                 backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_bear
             ),
             CharacterListItem(
                 type = CharacterType.BIRD,
-                imageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_bird_selected,
+                selectedImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_bird_selected,
+                defaultImageResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.img_bird_default,
                 nameResId = R.string.bird_name,
                 backgroundResId = com.goalpanzi.mission_mate.core.designsystem.R.drawable.background_bird
             )


### PR DESCRIPTION
## 주요 내용
- 보드판에서 미션 조회할 수 없을 때 온보딩 화면으로 이동 처리
- 종일 시간 수정
- 보드 스토리 이름 테두리 추가
- 닉네임 padding 처리
- 경쟁 시작 전 말풍선과 캐릭터 사이의 margin 줄이기
- 스토리에서 “나”는 무조건 opacity 1f로 설정
- 프로필 설정에서 CharacterLargeImage 그림자 없는 이미지로 수정
- 초대 코드 입력 로직 수정