### PR TITLE
Fix/board bottom blur

### DIFF
--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/Board.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/Board.kt
@@ -1,13 +1,21 @@
 package com.goalpanzi.mission_mate.feature.board.component
 
 import android.annotation.SuppressLint
+import android.util.Log
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
+import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.ScrollableDefaults
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBars
@@ -15,9 +23,11 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.overscroll
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -26,10 +36,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import com.goalpanzi.mission_mate.core.designsystem.theme.ColorGray1_FF404249
 import com.goalpanzi.mission_mate.core.designsystem.theme.ColorGray2_FF4F505C
@@ -46,7 +59,6 @@ import com.goalpanzi.mission_mate.feature.board.util.BoardManager.getPositionScr
 import com.goalpanzi.core.model.response.MissionVerificationResponse
 import kotlin.math.absoluteValue
 
-
 @Composable
 fun Board(
     scrollState: ScrollState,
@@ -59,14 +71,19 @@ fun Board(
     onClickPassedBlock : (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val statusBar = WindowInsets.statusBars
-    val navigationBar = WindowInsets.navigationBars
+    val statusBarPaddingValue = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val navigationPaddingValue = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val localDensity = LocalDensity.current
     val configuration = LocalConfiguration.current
     val statusBarHeight =
-        remember { (statusBar.getTop(localDensity) - statusBar.getBottom(localDensity)).absoluteValue }
+        remember(statusBarPaddingValue) { statusBarPaddingValue }
+    val bottomViewHeight = remember(navigationPaddingValue) {
+        142.dp + navigationPaddingValue
+    }
     val navigationBarHeight =
-        remember { (navigationBar.getTop(localDensity) - navigationBar.getBottom(localDensity)).absoluteValue }
+        remember(navigationPaddingValue) {
+            navigationPaddingValue
+        }
     val isVisiblePieces by remember(missionState) { derivedStateOf { missionState.isVisiblePiece() } }
     val myIndex by remember(missionBoards) {
         derivedStateOf {
@@ -86,7 +103,6 @@ fun Board(
             )
         )
     }
-
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -97,7 +113,7 @@ fun Board(
                 isVisiblePieces = isVisiblePieces,
                 innerModifier = Modifier
                     .drawWithContent {
-                        clipRect(bottom = statusBarHeight + 178.dp.toPx()) {
+                        clipRect(bottom = statusBarHeight.toPx() + 178.dp.toPx()) {
                             this@drawWithContent.drawContent()
                         }
                     }
@@ -123,11 +139,11 @@ fun Board(
                 innerModifier = Modifier
                     .drawWithContent {
                         clipRect(
-                            top = statusBarHeight + 178.dp.toPx() - 1,
+                            top = statusBarHeight.toPx() + 178.dp.toPx() - 1,
                             bottom = if (!isVisiblePieces) {
                                 size.height
                             } else {
-                                size.height + navigationBarHeight - 188.dp.toPx()
+                                size.height + navigationBarHeight.toPx() - bottomViewHeight.toPx() + 1.dp.toPx()
                             }
                         ) {
                             this@drawWithContent.drawContent()
@@ -154,7 +170,7 @@ fun Board(
                     isVisiblePieces = isVisiblePieces,
                     innerModifier = Modifier
                         .drawWithContent {
-                            clipRect(top = (size.height + navigationBarHeight - 188.dp.toPx())) {
+                            clipRect(top = (size.height + navigationBarHeight.toPx() - bottomViewHeight.toPx() + 1.dp.toPx())) {
                                 this@drawWithContent.drawContent()
                             }
                         }
@@ -175,7 +191,6 @@ fun Board(
             }
         }
     }
-
 }
 
 @Composable
@@ -263,6 +278,7 @@ fun ColumnScope.BoardContent(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @SuppressLint("ModifierFactoryUnreferencedReceiver")
 fun Modifier.modifierWithClipRect(
     scrollState: ScrollState,
@@ -274,7 +290,9 @@ fun Modifier.modifierWithClipRect(
         .fillMaxSize()
         .navigationBarsPadding()
         .then(innerModifier)
-        .verticalScroll(scrollState)
+        .verticalScroll(
+            state = scrollState
+        )
         .statusBarsPadding()
         .padding(
             top = 180.dp,

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/Board.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/Board.kt
@@ -59,6 +59,8 @@ import com.goalpanzi.mission_mate.feature.board.util.BoardManager.getPositionScr
 import com.goalpanzi.core.model.response.MissionVerificationResponse
 import kotlin.math.absoluteValue
 
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun Board(
     scrollState: ScrollState,
@@ -103,94 +105,101 @@ fun Board(
             )
         )
     }
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-    ) {
-        Column(
-            modifier = modifier.modifierWithClipRect(
-                scrollState = scrollState,
-                isVisiblePieces = isVisiblePieces,
-                innerModifier = Modifier
-                    .drawWithContent {
-                        clipRect(bottom = statusBarHeight.toPx() + 178.dp.toPx()) {
-                            this@drawWithContent.drawContent()
-                        }
-                    }
-                    .blur(10.dp, 10.dp),
-            )
-        ) {
-            BoardContent(
-                missionBoards,
-                missionDetail,
-                numberOfColumns,
-                boardPieces,
-                profile,
-                missionState,
-                isVisiblePieces = isVisiblePieces,
-                onClickPassedBlock = onClickPassedBlock,
-                modifier
-            )
-        }
-        Column(
-            modifier = modifier.modifierWithClipRect(
-                scrollState = scrollState,
-                isVisiblePieces = isVisiblePieces,
-                innerModifier = Modifier
-                    .drawWithContent {
-                        clipRect(
-                            top = statusBarHeight.toPx() + 178.dp.toPx() - 1,
-                            bottom = if (!isVisiblePieces) {
-                                size.height
-                            } else {
-                                size.height + navigationBarHeight.toPx() - bottomViewHeight.toPx() + 1.dp.toPx()
-                            }
-                        ) {
-                            this@drawWithContent.drawContent()
-                        }
-                    }
-            )
-        ) {
-            BoardContent(
-                missionBoards,
-                missionDetail,
-                numberOfColumns,
-                boardPieces,
-                profile,
-                missionState,
-                isVisiblePieces = isVisiblePieces,
-                onClickPassedBlock = onClickPassedBlock,
-                modifier
-            )
-        }
-        if (isVisiblePieces) {
-            Column(
-                modifier = modifier.modifierWithClipRect(
-                    scrollState = scrollState,
-                    isVisiblePieces = isVisiblePieces,
-                    innerModifier = Modifier
-                        .drawWithContent {
-                            clipRect(top = (size.height + navigationBarHeight.toPx() - bottomViewHeight.toPx() + 1.dp.toPx())) {
-                                this@drawWithContent.drawContent()
-                            }
-                        }
-                        .blur(10.dp, 10.dp)
-                )
+    CompositionLocalProvider(
+        LocalOverscrollConfiguration provides null,
+        content = {
+            Box(
+                modifier = modifier
+                    .fillMaxSize()
             ) {
-                BoardContent(
-                    missionBoards,
-                    missionDetail,
-                    numberOfColumns,
-                    boardPieces,
-                    profile,
-                    missionState,
-                    isVisiblePieces = isVisiblePieces,
-                    onClickPassedBlock = onClickPassedBlock,
-                    modifier
-                )
+                Column(
+                    modifier = modifier.modifierWithClipRect(
+                        scrollState = scrollState,
+                        isVisiblePieces = isVisiblePieces,
+                        innerModifier = Modifier
+                            .drawWithContent {
+                                clipRect(bottom = statusBarHeight.toPx() + 178.dp.toPx()) {
+                                    this@drawWithContent.drawContent()
+                                }
+                            }
+                            .blur(10.dp, 10.dp),
+                    )
+                ) {
+                    BoardContent(
+                        missionBoards,
+                        missionDetail,
+                        numberOfColumns,
+                        boardPieces,
+                        profile,
+                        missionState,
+                        isVisiblePieces = isVisiblePieces,
+                        onClickPassedBlock = onClickPassedBlock,
+                        modifier
+                    )
+                }
+                Column(
+                    modifier = modifier.modifierWithClipRect(
+                        scrollState = scrollState,
+                        isVisiblePieces = isVisiblePieces,
+                        innerModifier = Modifier
+                            .drawWithContent {
+                                clipRect(
+                                    top = statusBarHeight.toPx() + 178.dp.toPx() - 1,
+                                    bottom = if (!isVisiblePieces) {
+                                        size.height
+                                    } else {
+                                        size.height + navigationBarHeight.toPx() - bottomViewHeight.toPx() + 1.dp.toPx()
+                                    }
+                                ) {
+                                    this@drawWithContent.drawContent()
+                                }
+                            }
+                    )
+                ) {
+                    BoardContent(
+                        missionBoards,
+                        missionDetail,
+                        numberOfColumns,
+                        boardPieces,
+                        profile,
+                        missionState,
+                        isVisiblePieces = isVisiblePieces,
+                        onClickPassedBlock = onClickPassedBlock,
+                        modifier
+                    )
+                }
+                if (isVisiblePieces) {
+                    Column(
+                        modifier = modifier.modifierWithClipRect(
+                            scrollState = scrollState,
+                            isVisiblePieces = isVisiblePieces,
+                            innerModifier = Modifier
+                                .drawWithContent {
+                                    clipRect(top = (size.height + navigationBarHeight.toPx() - bottomViewHeight.toPx() + 1.dp.toPx())) {
+                                        this@drawWithContent.drawContent()
+                                    }
+                                }
+                                .blur(10.dp, 10.dp)
+                        )
+                    ) {
+                        BoardContent(
+                            missionBoards,
+                            missionDetail,
+                            numberOfColumns,
+                            boardPieces,
+                            profile,
+                            missionState,
+                            isVisiblePieces = isVisiblePieces,
+                            onClickPassedBlock = onClickPassedBlock,
+                            modifier
+                        )
+                    }
+                }
             }
         }
-    }
+    )
+
+
 }
 
 @Composable


### PR DESCRIPTION
## 수정 사항
네비게이션 숨김 시 숨김 처리전 네비게이션 높이만큼 blur를 유지하는 이슈 수정
-수정 전
<img src="https://github.com/user-attachments/assets/6f15ddd1-21d6-4656-abb4-ef030459815f" width="240px"/>

-수정 후
<img src="https://github.com/user-attachments/assets/58a59ec0-819b-445f-bc4f-12d64f6e7e9cf" width="240px"/>

추가로 스크롤이 아래로 끝에 위치했을 때 한번 더 스크롤 하면 overScroll 이 적용되는데 blur 처리한 부분에서 자연스럽지 못하다고 판단하여 overScroll을 제거하였습니다. 해당 현상은 gif 첨부하였고, 수정 후는 따로 gif가 없고 overScroll 효과가 없는 것으로 보시면 될 것 같습니다.
<img src="https://github.com/user-attachments/assets/c93cddb0-c3ed-4a0f-9bee-a997b0726b45" width="240px"/>


