### PR TITLE
Refactor network모듈의 datastore에 대한 의존성 제거

### DIFF
--- a/core/data/auth/src/main/java/com/goalpanzi/mission_mate/core/data/auth/AuthTokenProvider.kt
+++ b/core/data/auth/src/main/java/com/goalpanzi/mission_mate/core/data/auth/AuthTokenProvider.kt
@@ -1,0 +1,28 @@
+package com.goalpanzi.mission_mate.core.data.auth
+
+import com.goalpanzi.mission_mate.core.datastore.datasource.AuthDataSource
+import com.goalpanzi.mission_mate.core.network.TokenProvider
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+
+class AuthTokenProvider @Inject constructor(
+    private val authDataSource: AuthDataSource
+) : TokenProvider {
+    override suspend fun getAccessToken(): String? {
+        return authDataSource.getAccessToken().firstOrNull()
+    }
+
+    override suspend fun getRefreshToken(): String? {
+        return authDataSource.getRefreshToken().firstOrNull()
+    }
+
+    override suspend fun setAccessToken(accessToken: String) {
+        authDataSource.setAccessToken(accessToken)
+    }
+
+    override suspend fun setRefreshToken(refreshToken: String) {
+        authDataSource.setRefreshToken(refreshToken)
+    }
+
+
+}

--- a/core/data/auth/src/main/java/com/goalpanzi/mission_mate/core/data/auth/di/AuthDataModule.kt
+++ b/core/data/auth/src/main/java/com/goalpanzi/mission_mate/core/data/auth/di/AuthDataModule.kt
@@ -1,7 +1,9 @@
 package com.goalpanzi.mission_mate.core.data.auth.di
 
+import com.goalpanzi.mission_mate.core.data.auth.AuthTokenProvider
 import com.goalpanzi.mission_mate.core.data.auth.repository.AuthRepositoryImpl
 import com.goalpanzi.mission_mate.core.domain.auth.repository.AuthRepository
+import com.goalpanzi.mission_mate.core.network.TokenProvider
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -14,4 +16,6 @@ internal abstract class AuthDataModule {
     @Binds
     abstract fun bindLoginRepository(impl: AuthRepositoryImpl): AuthRepository
 
+    @Binds
+    abstract fun bindTokenProvider(impl : AuthTokenProvider) : TokenProvider
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -55,8 +55,6 @@ dependencies {
     ksp(libs.hilt.compiler)
     implementation(libs.hilt.android)
 
-
-    implementation(project(":core:datastore"))
 }
 
 fun getMissionMateBaseUrl(): String {

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/TokenProvider.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/TokenProvider.kt
@@ -1,0 +1,8 @@
+package com.goalpanzi.mission_mate.core.network
+
+interface TokenProvider {
+    suspend fun getAccessToken(): String?
+    suspend fun getRefreshToken() : String?
+    suspend fun setAccessToken(accessToken : String)
+    suspend fun setRefreshToken(refreshToken : String)
+}

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/di/ServiceModule.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/di/ServiceModule.kt
@@ -1,8 +1,7 @@
 package com.goalpanzi.mission_mate.core.network.di
 
-import android.util.Log
-import com.goalpanzi.mission_mate.core.datastore.datasource.AuthDataSource
 import com.goalpanzi.mission_mate.core.network.BuildConfig
+import com.goalpanzi.mission_mate.core.network.TokenProvider
 import com.goalpanzi.mission_mate.core.network.service.LoginService
 import com.goalpanzi.mission_mate.core.network.service.MissionService
 import com.goalpanzi.mission_mate.core.network.service.OnboardingService
@@ -12,11 +11,9 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
 import retrofit2.Retrofit
@@ -55,12 +52,12 @@ object ServiceModule {
     fun provideTokenService(
         httpLoggingInterceptor: HttpLoggingInterceptor,
         converterFactory: Converter.Factory,
-        authDataSource: AuthDataSource
+        tokenProvider: TokenProvider
     ): TokenService {
         val tokenReissueInterceptor = Interceptor { chain ->
             val newRequest = chain.request().newBuilder().apply {
                 runBlocking {
-                    val token = authDataSource.getAccessToken().first()
+                    val token = tokenProvider.getAccessToken()
                     token?.let {
                         addHeader("Authorization", "Bearer $it")
                     }


### PR DESCRIPTION
## 주요 내용
1. core:network 모듈에 TokenProvider interpace를 추가하였습니다.
2. core:data:auth 모듈에서 TokenProvider 를 구현하는 구현체 AuthTokenProvider를 만들고, AuthDataModule에서 의존성 주입을 설정합니다.
3. core:network에서 core:datastore에 대한 의존성을 제거하고 TokenProvider를 통해 토큰 관련 로직을 실행하도록 하였습니다.