### PR TITLE
LoginViewModel - Context 참조 제거

### DIFF
--- a/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginManager.kt
+++ b/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginManager.kt
@@ -1,0 +1,61 @@
+package com.goalpanzi.mission_mate.feature.login
+
+import android.content.Context
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+sealed class LoginData {
+    data class Success(val email : String) : LoginData()
+    data class Failed(val exception: Exception) : LoginData()
+}
+
+class LoginManager (
+    private val context : Context
+) {
+    suspend fun request() : LoginData = withContext(Dispatchers.IO) {
+        val credentialManager = CredentialManager.create(context)
+        val signInWithGoogleOption: GetSignInWithGoogleOption =
+            GetSignInWithGoogleOption.Builder(BuildConfig.CREDENTIAL_WEB_CLIENT_ID)
+                .build()
+
+        val request: GetCredentialRequest = GetCredentialRequest.Builder()
+            .addCredentialOption(signInWithGoogleOption)
+            .build()
+
+        return@withContext try {
+            val result = credentialManager.getCredential(context, request)
+            handleSignIn(result)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            LoginData.Failed(e)
+        }
+    }
+
+    private fun handleSignIn(response: GetCredentialResponse) : LoginData {
+        return when (val credential = response.credential) {
+            is CustomCredential -> {
+                if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                    try {
+                        val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
+                        LoginData.Success(googleIdTokenCredential.id)
+                    } catch (e: GoogleIdTokenParsingException) {
+                        LoginData.Failed(e)
+                    }
+                }else {
+                    LoginData.Failed(RuntimeException("Credential Type not equals TYPE_GOOGLE_ID_TOKEN_CREDENTIAL"))
+                }
+            }
+
+            else -> {
+                LoginData.Failed(RuntimeException("Credential is not CustomCredential"))
+            }
+        }
+    }
+}

--- a/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginManager.kt
+++ b/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginManager.kt
@@ -49,12 +49,12 @@ class LoginManager (
                         LoginData.Failed(e)
                     }
                 }else {
-                    LoginData.Failed(RuntimeException("Credential Type not equals TYPE_GOOGLE_ID_TOKEN_CREDENTIAL"))
+                    LoginData.Failed(RuntimeException("NoDataException"))
                 }
             }
 
             else -> {
-                LoginData.Failed(RuntimeException("Credential is not CustomCredential"))
+                LoginData.Failed(IllegalStateException())
             }
         }
     }

--- a/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginScreen.kt
@@ -11,13 +11,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,16 +34,18 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.goalpanzi.mission_mate.core.designsystem.theme.ColorWhite_FFFFFFFF
 import com.goalpanzi.mission_mate.core.designsystem.theme.Color_FFFF5632
 import com.goalpanzi.mission_mate.core.designsystem.theme.MissionMateTypography
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @Composable
 fun LoginRoute(
     onLoginSuccess: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    coroutineScope : CoroutineScope = rememberCoroutineScope(),
+    loginManager: LoginManager = rememberLoginManager(),
     viewModel: LoginViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
-
     LaunchedEffect(true) {
         viewModel.eventFlow.collectLatest {
             when (it) {
@@ -54,8 +57,20 @@ fun LoginRoute(
 
     LoginScreen(
         modifier = modifier,
-        onGoogleLoginClick = { viewModel.request(context) }
+        onGoogleLoginClick = {
+            coroutineScope.launch {
+                viewModel.login(loginManager.request())
+            }
+        }
     )
+}
+
+@Composable
+private fun rememberLoginManager(): LoginManager {
+    val context = LocalContext.current
+    return remember {
+        LoginManager(context)
+    }
 }
 
 @Composable

--- a/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginViewModel.kt
@@ -1,16 +1,8 @@
 package com.goalpanzi.mission_mate.feature.login
 
-import android.content.Context
-import androidx.credentials.CredentialManager
-import androidx.credentials.CustomCredential
-import androidx.credentials.GetCredentialRequest
-import androidx.credentials.GetCredentialResponse
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.goalpanzi.mission_mate.core.domain.auth.usecase.LoginUseCase
-import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
-import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
-import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -25,33 +17,12 @@ class LoginViewModel @Inject constructor(
     private val _eventFlow = MutableSharedFlow<LoginEvent>()
     val eventFlow = _eventFlow.asSharedFlow()
 
-    fun request(context: Context) {
-        viewModelScope.launch {
-            val credentialManager = CredentialManager.create(context)
-            val signInWithGoogleOption: GetSignInWithGoogleOption =
-                GetSignInWithGoogleOption.Builder(BuildConfig.CREDENTIAL_WEB_CLIENT_ID)
-                    .build()
-
-            val request: GetCredentialRequest = GetCredentialRequest.Builder()
-                .addCredentialOption(signInWithGoogleOption)
-                .build()
-
-            try {
-                val result = credentialManager.getCredential(context, request)
-                handleSignIn(result)
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-    }
-
-    private suspend fun handleSignIn(response: GetCredentialResponse) {
-        when (val credential = response.credential) {
-            is CustomCredential -> {
-                if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+    fun login(loginData: LoginData){
+        when(loginData){
+            is LoginData.Success -> {
+                viewModelScope.launch {
                     try {
-                        val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
-                        val result = loginUseCase.requestGoogleLogin(email = googleIdTokenCredential.id)
+                        val result = loginUseCase.requestGoogleLogin(email = loginData.email)
                         _eventFlow.emit(
                             result?.let {
                                 LoginEvent.Success(it.isProfileSet)
@@ -59,14 +30,13 @@ class LoginViewModel @Inject constructor(
                                 LoginEvent.Error
                             }
                         )
-                    } catch (e: GoogleIdTokenParsingException) {
+                    }catch (e: Exception){
                         e.printStackTrace()
                     }
                 }
             }
-
-            else -> {
-                // TODO : error event
+            is LoginData.Failed -> {
+                loginData.exception.printStackTrace()
             }
         }
     }

--- a/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginViewModel.kt
@@ -17,22 +17,20 @@ class LoginViewModel @Inject constructor(
     private val _eventFlow = MutableSharedFlow<LoginEvent>()
     val eventFlow = _eventFlow.asSharedFlow()
 
-    fun login(loginData: LoginData){
+    suspend fun login(loginData: LoginData){
         when(loginData){
             is LoginData.Success -> {
-                viewModelScope.launch {
-                    try {
-                        val result = loginUseCase.requestGoogleLogin(email = loginData.email)
-                        _eventFlow.emit(
-                            result?.let {
-                                LoginEvent.Success(it.isProfileSet)
-                            } ?: run {
-                                LoginEvent.Error
-                            }
-                        )
-                    }catch (e: Exception){
-                        e.printStackTrace()
-                    }
+                try {
+                    val result = loginUseCase.requestGoogleLogin(email = loginData.email)
+                    _eventFlow.emit(
+                        result?.let {
+                            LoginEvent.Success(it.isProfileSet)
+                        } ?: run {
+                            LoginEvent.Error
+                        }
+                    )
+                }catch (e: Exception){
+                    e.printStackTrace()
                 }
             }
             is LoginData.Failed -> {


### PR DESCRIPTION
## 주요 내용
- LoginViewModel 에서 Context를 받아서 처리하는 로직이 있어 개선하였습니다.
  - LoginManager 클래스를 만들어 context를 받아서 Google 로그인 관련 로직을 처리하도록 하였습니다.
  - LoginManager의 생성 및 소멸 시점을 LoginScreen과 동일하게 가져가면 될 것으로 판단하여 LoginScreen 내에서 객체를 생성하였고, remember를 사용하여 recomposition 시 재생성을 막도록 하였습니다.
  - LoginData 라는 sealed class를 추가하였습니다. Success인 경우 email를 , Failed 인 경우 Exception을 받을 수 있습니다.

### 참고 
아래는 ViewModel이 Activity의 Context를 참조하면 안되는 이유를 개인적으로 정리하였던 내용인데 공유하면 좋을 것 같아 같이 남겨두었습니다. 

#### ViewModel이 Activity의 Context를 참조하면 안 되는 이유
https://developer.android.com/topic/libraries/architecture/viewmodel?hl=ko#best-practices

ViewModel은 UI 관련 데이터를 관리하고 Configuration Change 시에도 데이터를 유지하도록 설계되었습니다. 이러한 특성 때문 ViewModel은 Activity나 Fragment의 생명주기와 독립적으로 동작합니다. 따라서 ViewModel이 Activity의 Context를 참조하게 되면 다음과 같은 문제가 발생할 수 있습니다:
* 메모리 누수(Memory Leak): ViewModel은 Activity보다 더 오래 생존할 수 있습니다. 만약 ViewModel이 Activity의 Context를 참조하게 되면, Activity가 소멸된 후에도 ViewModel이 Context를 계속 참조하게 되어 메모리 누수가 발생할 수 있습니다.
* 생명주기 불일치(Lifecycle Mismatch): Context는 Activity의 생명주기에 종속되지만, ViewModel은 그보다 더 긴 생명주기를 가집니다. 이는 ViewModel에서 Context를 사용할 때 예기치 않은 동작이나 크래시를 초래할 수 있습니다.
