### PR TITLE
보드판 애니메이션 개선

### DIFF
--- a/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/board/mapper/MissionMapper.kt
+++ b/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/board/mapper/MissionMapper.kt
@@ -43,6 +43,7 @@ fun MissionBoardResponse.toModel() : MissionBoard {
 
 fun MissionBoardMembersResponse.toModel() : MissionBoardMembers {
     return MissionBoardMembers(
+        memberId = memberId,
         nickname = nickname,
         characterType = characterType.toModel()
     )

--- a/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/model/MissionBoardMembers.kt
+++ b/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/model/MissionBoardMembers.kt
@@ -3,6 +3,7 @@ package com.goalpanzi.mission_mate.core.domain.mission.model
 import com.goalpanzi.mission_mate.core.domain.common.model.user.CharacterType
 
 data class MissionBoardMembers(
+    val memberId : Long,
     val nickname : String,
     val characterType : CharacterType = CharacterType.RABBIT
 )

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/response/MissionBoardMembersResponse.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/response/MissionBoardMembersResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class MissionBoardMembersResponse(
-    //val memberId : Long,
+    val memberId : Long,
     val nickname : String,
     val characterType : CharacterTypeResponse = CharacterTypeResponse.RABBIT
 )

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/Piece.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/Piece.kt
@@ -1,8 +1,14 @@
 package com.goalpanzi.mission_mate.feature.board.component
 
+import android.util.Log
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -12,18 +18,23 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -37,6 +48,8 @@ import com.goalpanzi.mission_mate.feature.board.model.BoardPieceType
 import com.goalpanzi.mission_mate.feature.board.util.PieceGenerator
 import com.goalpanzi.mission_mate.core.designsystem.component.OutlinedChip
 import com.goalpanzi.mission_mate.core.designsystem.component.StableImage
+import com.goalpanzi.mission_mate.feature.board.model.MotionType
+import kotlinx.coroutines.delay
 
 @Composable
 fun BoxScope.Piece(
@@ -45,28 +58,38 @@ fun BoxScope.Piece(
     sizePerBlock: Dp,
     modifier: Modifier = Modifier
 ) {
-    val isAnimated by remember(boardPiece) {
-        derivedStateOf { boardPiece.boardPieceType == BoardPieceType.MOVED }
+    val isAnimated by remember {
+        derivedStateOf {
+            boardPiece.motionType in setOf(
+                MotionType.MOVE_FADE_IN,
+                MotionType.MOVE,
+                MotionType.MOVE_FADE_OUT,
+                MotionType.FADE_IN_MOVE_FADE_OUT
+            )
+        }
     }
+
+    val alpha = animatedFloatByMotionType(boardPiece.motionType, 600)
+
     val x = animateDpAsState(
         targetValue = if (isAnimated) PieceGenerator.getXOffset(
-            boardPiece.index + 1,
+            boardPiece.index,
             numberOfColumn,
             sizePerBlock
-        ) else PieceGenerator.getXOffset(boardPiece.index , numberOfColumn, sizePerBlock),
+        ) else PieceGenerator.getXOffset(boardPiece.index, numberOfColumn, sizePerBlock),
         animationSpec = tween(
-            durationMillis = 500,
+            durationMillis = 650,
             easing = LinearOutSlowInEasing
         )
     )
     val y = animateDpAsState(
         targetValue = if (isAnimated) PieceGenerator.getYOffset(
-            boardPiece.index  + 1,
+            boardPiece.index,
             numberOfColumn,
             sizePerBlock
-        ) else PieceGenerator.getYOffset(boardPiece.index , numberOfColumn, sizePerBlock),
+        ) else PieceGenerator.getYOffset(boardPiece.index, numberOfColumn, sizePerBlock),
         animationSpec = tween(
-            durationMillis = 500,
+            durationMillis = 650,
             easing = LinearOutSlowInEasing
         )
     )
@@ -82,45 +105,108 @@ fun BoxScope.Piece(
                 sizePerBlock
             )
     ) {
-        if(boardPiece.boardPieceType != BoardPieceType.HIDDEN){
-            StableImage(
-                modifier = Modifier
-                    .padding(top = 4.dp)
-                    .fillMaxWidth(88f / 114f)
-                    .aspectRatio(1f)
-                    .align(Alignment.TopCenter),
-                drawableResId = boardPiece.drawableRes,
-            )
-            if(boardPiece.count > 1){
-                PieceCountChip(
-                    modifier = Modifier.align(Alignment.TopEnd),
-                    count = boardPiece.count,
-                    imageId = boardPiece.drawableRes
-                )
-            }
-            PieceNameChip(
-                modifier = Modifier
-                    .align(
-                        Alignment.BottomCenter
-                    )
-                    .padding(bottom = 7.dp),
-                name = boardPiece.nickname,
-                isMe = boardPiece.isMe
+        if (boardPiece.boardPieceType == BoardPieceType.HIDDEN && boardPiece.motionType in setOf(MotionType.HIDE,MotionType.STATIC)) return
+        StableImage(
+            modifier = Modifier
+                .padding(top = 4.dp)
+                .fillMaxWidth(88f / 114f)
+                .alpha(alpha)
+                .aspectRatio(1f)
+                .align(Alignment.TopCenter),
+            drawableResId = boardPiece.drawableRes,
+        )
+        if (boardPiece.count > 1 && boardPiece.boardPieceType != BoardPieceType.HIDDEN) {
+            PieceCountChip(
+                modifier = Modifier.align(Alignment.TopEnd),
+                count = boardPiece.count,
+                imageId = boardPiece.drawableRes
             )
         }
+        if(boardPiece.boardPieceType != BoardPieceType.HIDDEN)
+        PieceNameChip(
+            modifier = Modifier
+                .align(
+                    Alignment.BottomCenter
+                )
+                .padding(bottom = 7.dp),
+            name = boardPiece.nickname,
+            isMe = boardPiece.isMe
+        )
+    }
+}
 
+
+@Composable
+fun animatedFloatByMotionType(
+    motionType: MotionType,
+    durationMillis: Int
+): Float {
+    val animatable = remember { Animatable(1f) }
+
+    LaunchedEffect(motionType) {
+        when (motionType) {
+            MotionType.STATIC, MotionType.MOVE, MotionType.HIDE -> {
+                animatable.snapTo(if (motionType == MotionType.HIDE) 0f else 1f)
+            }
+            MotionType.FADE_IN, MotionType.MOVE_FADE_IN -> {
+                animatable.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(
+                        durationMillis = durationMillis * 1 / 5,
+                        easing = LinearEasing
+                    )
+                )
+                animatable.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(durationMillis = durationMillis * 4 / 5)
+                )
+            }
+            MotionType.FADE_OUT, MotionType.MOVE_FADE_OUT -> {
+                animatable.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(durationMillis = durationMillis * 3 / 5)
+                )
+                animatable.animateTo(
+                    targetValue = 0f,
+                    animationSpec = tween(
+                        durationMillis = durationMillis * 2 / 5,
+                        easing = LinearEasing
+                    )
+                )
+            }
+            MotionType.FADE_IN_MOVE_FADE_OUT -> {
+                animatable.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(
+                        durationMillis = durationMillis * 1 / 5,
+                        easing = LinearEasing
+                    )
+                )
+                animatable.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(durationMillis = durationMillis * 3 / 5)
+                )
+                animatable.animateTo(
+                    targetValue = 0f,
+                    animationSpec = tween(
+                        durationMillis = durationMillis * 1 / 5,
+                        easing = LinearEasing
+                    )
+                )
+            }
+        }
     }
 
-
+    return animatable.value
 }
 
 @Composable
 fun PieceNameChip(
-    name : String,
+    name: String,
     modifier: Modifier = Modifier,
-    isMe : Boolean = false,
-    textStyle : TextStyle = MissionMateTypography.body_md_bold
-){
+    isMe: Boolean = false,
+    textStyle: TextStyle = MissionMateTypography.body_md_bold
+) {
     Text(
         modifier = modifier
             .padding(horizontal = 12.dp)
@@ -130,11 +216,10 @@ fun PieceNameChip(
             .background(
                 if (isMe) ColorOrange_FFFF5732 else ColorWhite_FFFFFFFF
             )
-            .padding(horizontal = 8.5.dp, 0.85.dp)
-        ,
+            .padding(horizontal = 8.5.dp, 0.85.dp),
         text = name,
         style = textStyle,
-        color = if(isMe) ColorWhite_FFFFFFFF else ColorGray1_FF404249,
+        color = if (isMe) ColorWhite_FFFFFFFF else ColorGray1_FF404249,
         textAlign = TextAlign.Center
     )
 }
@@ -142,17 +227,17 @@ fun PieceNameChip(
 @Composable
 fun PieceCountChip(
     @DrawableRes imageId: Int,
-    count : Int,
+    count: Int,
     modifier: Modifier = Modifier,
-    textStyle : TextStyle = MissionMateTypography.body_md_bold
-){
+    textStyle: TextStyle = MissionMateTypography.body_md_bold
+) {
     OutlinedChip(
         modifier = modifier
-    ){
+    ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(5.dp)
-        ){
+        ) {
             StableImage(
                 modifier = Modifier.size(22.dp),
                 drawableResId = imageId,

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/BoardPiece.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/BoardPiece.kt
@@ -1,6 +1,7 @@
 package com.goalpanzi.mission_mate.feature.board.model
 
 data class BoardPiece(
+    val memberId : Long,
     val index : Int,
     val count : Int,
     val nickname : String,

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/BoardPiece.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/BoardPiece.kt
@@ -7,12 +7,25 @@ data class BoardPiece(
     val nickname : String,
     val isMe : Boolean,
     val drawableRes: Int,
-    val boardPieceType: BoardPieceType = BoardPieceType.INITIAL
-)
+    val boardPieceType: BoardPieceType = BoardPieceType.INITIAL,
+    val motionType : MotionType = MotionType.STATIC,
+    val order : Int = 0
+){
+    val needToDraw = boardPieceType == BoardPieceType.HIDDEN && motionType in setOf(MotionType.STATIC,MotionType.HIDE,MotionType.FADE_OUT)
+}
 
 enum class BoardPieceType {
     INITIAL,
-    MOVED,
-    NOT_CHANGED,
     HIDDEN
+}
+
+enum class MotionType {
+    STATIC,
+    MOVE,
+    HIDE,
+    FADE_IN,
+    FADE_OUT,
+    MOVE_FADE_IN,
+    MOVE_FADE_OUT,
+    FADE_IN_MOVE_FADE_OUT
 }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/MissionBoardsUiModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/MissionBoardsUiModel.kt
@@ -29,17 +29,19 @@ fun MissionBoards.toUiModel() : MissionBoardsUiModel {
 fun MissionBoardsUiModel.toBoardPieces(
     profile: UserProfile?
 ) : List<BoardPiece> {
-    return missionBoardList.filter { block ->
-        block.missionBoardMembers.isNotEmpty()
-    }.map { block ->
-        BoardPiece(
-            index = block.number,
-            count = block.missionBoardMembers.size,
-            nickname = if(block.isMyPosition && profile != null) profile.nickname
-                       else block.missionBoardMembers.first().nickname,
-            isMe = block.isMyPosition,
-            drawableRes = if(block.isMyPosition && profile != null) profile.characterType.toCharacterUiModel().imageId
-                          else block.missionBoardMembers.first().characterType.toCharacterUiModel().imageId
-        )
-    }
+    return missionBoardList.map { block ->
+        block.missionBoardMembers.mapIndexed { index,  member ->
+            BoardPiece(
+                memberId = member.memberId,
+                index = block.number,
+                count = block.missionBoardMembers.size,
+                nickname = member.nickname,
+                isMe = block.isMyPosition,
+                drawableRes = member.characterType.toCharacterUiModel().imageId,
+                boardPieceType = if(block.missionBoardMembers.firstOrNull()?.memberId == member.memberId) BoardPieceType.INITIAL
+                                else BoardPieceType.HIDDEN,
+                order = index
+            )
+        }.reversed()
+    }.flatten()
 }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
@@ -141,12 +141,6 @@ fun BoardRoute(
         }
     }
 
-    LaunchedEffect(key1 = isUploadSuccess) {
-        if (isUploadSuccess) {
-            viewModel.onVerifySuccess()
-        }
-    }
-
     if (isShownDeleteMissionDialog) {
         DeleteMissionDialog(
             onDismissRequest = {

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -16,7 +16,6 @@ import com.goalpanzi.mission_mate.core.domain.setting.usecase.SetViewedTooltipUs
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
 import com.goalpanzi.mission_mate.feature.board.model.BoardPiece
-import com.goalpanzi.mission_mate.feature.board.model.BoardPieceType
 import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.MissionState
 import com.goalpanzi.mission_mate.feature.board.model.MissionState.Companion.getMissionState
@@ -27,6 +26,7 @@ import com.goalpanzi.mission_mate.feature.board.model.toUiModel
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionBoardUiModel
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionUiModel
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionVerificationUiModel
+import com.goalpanzi.mission_mate.feature.board.util.PieceManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -57,7 +57,7 @@ class BoardViewModel @Inject constructor(
     private val profileUseCase: ProfileUseCase,
     private val setViewedTooltipUseCase: SetViewedTooltipUseCase,
     private val verifyMissionUseCase: VerifyMissionUseCase,
-    private val getMyMissionVerificationUseCase : GetMyMissionVerificationUseCase,
+    private val getMyMissionVerificationUseCase: GetMyMissionVerificationUseCase,
 ) : ViewModel() {
 
     val missionId: Long = savedStateHandle.get<Long>("missionId")!!
@@ -69,10 +69,10 @@ class BoardViewModel @Inject constructor(
     )
 
     private val _missionError = MutableStateFlow<MissionError?>(null)
-    val missionError : StateFlow<MissionError?> =_missionError.asStateFlow()
+    val missionError: StateFlow<MissionError?> = _missionError.asStateFlow()
 
     private val _myMissionVerification = MutableSharedFlow<UserStory>()
-    val myMissionVerification : SharedFlow<UserStory> = _myMissionVerification.asSharedFlow()
+    val myMissionVerification: SharedFlow<UserStory> = _myMissionVerification.asSharedFlow()
 
     private val _deleteMissionResultEvent = MutableSharedFlow<Boolean>()
     val deleteMissionResultEvent: SharedFlow<Boolean> = _deleteMissionResultEvent.asSharedFlow()
@@ -91,7 +91,7 @@ class BoardViewModel @Inject constructor(
         _missionVerificationUiModel.asStateFlow()
 
     private val _isRefreshLoading = MutableStateFlow(false)
-    val isRefreshLoading : StateFlow<Boolean> = _isRefreshLoading.asStateFlow()
+    val isRefreshLoading: StateFlow<Boolean> = _isRefreshLoading.asStateFlow()
 
     val isHost: StateFlow<Boolean> =
         combine(
@@ -124,7 +124,7 @@ class BoardViewModel @Inject constructor(
     private val _boardPieces = MutableStateFlow<List<BoardPiece>>(emptyList())
     val boardPieces: StateFlow<List<BoardPiece>> = _boardPieces.asStateFlow()
 
-    fun fetchMissionData(){
+    fun fetchMissionData() {
         viewModelScope.launch {
             getMissionBoards()
             getMission()
@@ -132,7 +132,7 @@ class BoardViewModel @Inject constructor(
         }
     }
 
-    fun refreshMissionData(){
+    fun refreshMissionData() {
         viewModelScope.launch {
             _isRefreshLoading.emit(true)
             joinAll(
@@ -151,16 +151,31 @@ class BoardViewModel @Inject constructor(
             }.collect {
                 when (it) {
                     is DomainResult.Success -> {
-                        _missionBoardUiModel.emit(
-                            MissionBoardUiModel.Success(
-                                it.data.toUiModel()
+                        _missionBoardUiModel.emit(MissionBoardUiModel.Success(it.data.toUiModel()))
+
+                        val boardPieceList =
+                            it.data.toUiModel().toBoardPieces(profileUseCase.getProfile())
+
+                        if (boardPieces.value.isEmpty()) {
+                            _boardPieces.emit(boardPieceList)
+                        } else {
+                            val isMoved =
+                                boardPieces.value.find { it.isMe }?.index?.plus(1) ==  boardPieceList.find { it.isMe }?.index
+
+                            val newList = PieceManager.getBoardPieces(
+                                boardPieces.value,
+                                boardPieceList
                             )
-                        )
-                        _boardPieces.emit(
-                            it.data.toUiModel().toBoardPieces(
-                                profileUseCase.getProfile()
+                            _boardPieces.emit(
+                                newList
                             )
-                        )
+                            if(isMoved){
+                                delay(550)
+                                _boardRewardEvent.emit(
+                                    it.data.missionBoards.find { it.isMyPosition }?.reward
+                                )
+                            }
+                        }
                     }
 
                     else -> {
@@ -222,77 +237,9 @@ class BoardViewModel @Inject constructor(
         }
     }
 
-    fun onVerifySuccess() {
-        if(missionState.value != MissionState.IN_PROGRESS_MISSION_DAY_BEFORE_CONFIRM) return
-        viewModelScope.launch {
-            // 내 캐릭터
-            val myBoardPiece = boardPieces.value.find { it.isMe }
-            val missionBoard = missionBoardUiModel.value
-            if (myBoardPiece != null && missionBoard is MissionBoardUiModel.Success) {
-                val missionBoardList = missionBoard.missionBoards.missionBoardList
-                // 내 캐릭터보다 한칸 앞션 캐릭터
-                val nextBoardPiece = missionBoardList.filter { block ->
-                    block.missionBoardMembers.isNotEmpty()
-                }.find {
-                    it.number == myBoardPiece.index + 1
-                }
-
-                // 내 캐릭터와 같이 있던 캐릭터
-                val prevBoardPiece = missionBoardList.filter { block ->
-                    block.missionBoardMembers.size >= 2
-                }.find {
-                    it.number == myBoardPiece.index
-                }
-                _boardPieces.emit(
-                    buildList {
-                        addAll(
-                            boardPieces.value.map {
-                                if (it.isMe) it.copy(
-                                    boardPieceType = BoardPieceType.MOVED,
-                                    count = if (nextBoardPiece != null) nextBoardPiece.missionBoardMembers.size + 1 else 1
-                                ) else if (nextBoardPiece != null && it.index == nextBoardPiece.number) {
-                                    it.copy(boardPieceType = BoardPieceType.HIDDEN)
-                                } else it
-                            }
-                        )
-                        if (prevBoardPiece != null) {
-                            val target = prevBoardPiece.missionBoardMembers.first {
-                                it.nickname != myBoardPiece.nickname
-                            }
-                            add(
-                                BoardPiece(
-                                    count = prevBoardPiece.missionBoardMembers.size - 1,
-                                    nickname = target.nickname,
-                                    drawableRes = target.characterType.toCharacterUiModel().imageId,
-                                    index = prevBoardPiece.number,
-                                    isMe = false
-                                )
-                            )
-                        }
-                    }
-                )
-
-                _missionBoardUiModel.emit(
-                    missionBoard.copy(
-                        missionBoards = missionBoard.missionBoards.copy(
-                            passedCountByMe = missionBoard.missionBoards.passedCountByMe + 1
-                        )
-                    )
-                )
-                delay(400)
-                _boardRewardEvent.emit(
-                    missionBoardList.find {
-                        myBoardPiece.index + 1 == it.number
-                    }?.reward
-                )
-            }
-            fetchMissionData()
-        }
-    }
-
     fun getMyMissionVerification(
-        number : Int
-    ){
+        number: Int
+    ) {
         viewModelScope.launch {
             getMyMissionVerificationUseCase(
                 missionId,
@@ -300,7 +247,7 @@ class BoardViewModel @Inject constructor(
             ).catch {
 
             }.collect {
-                when(it){
+                when (it) {
                     is DomainResult.Success -> {
                         _myMissionVerification.emit(
                             UserStory(
@@ -312,16 +259,12 @@ class BoardViewModel @Inject constructor(
                             )
                         )
                     }
+
                     else -> {
 
                     }
                 }
-
-
-
             }
-
         }
     }
-
 }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/util/PieceManager.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/util/PieceManager.kt
@@ -1,0 +1,56 @@
+package com.goalpanzi.mission_mate.feature.board.util
+
+import com.goalpanzi.mission_mate.feature.board.model.BoardPiece
+import com.goalpanzi.mission_mate.feature.board.model.BoardPieceType
+import com.goalpanzi.mission_mate.feature.board.model.MotionType
+
+object PieceManager {
+    fun getBoardPieces(
+        prevBoardPieces: List<BoardPiece>,
+        newBoardPieces: List<BoardPiece>
+    ): List<BoardPiece> {
+        val result = newBoardPieces.map { new ->
+            val prevBoardPiece = prevBoardPieces.find { it.memberId == new.memberId } ?: new
+            val sameIndex = prevBoardPiece.index == new.index
+
+            val motionType = when {
+                sameIndex -> when (prevBoardPiece.boardPieceType to new.boardPieceType) {
+                    BoardPieceType.INITIAL to BoardPieceType.INITIAL -> MotionType.STATIC
+                    BoardPieceType.INITIAL to BoardPieceType.HIDDEN -> MotionType.FADE_OUT
+                    BoardPieceType.HIDDEN to BoardPieceType.INITIAL -> MotionType.FADE_IN
+                    BoardPieceType.HIDDEN to BoardPieceType.HIDDEN -> MotionType.HIDE
+                    else -> new.motionType
+                }
+                else -> when (prevBoardPiece.boardPieceType to new.boardPieceType) {
+                    BoardPieceType.INITIAL to BoardPieceType.INITIAL -> MotionType.MOVE
+                    BoardPieceType.INITIAL to BoardPieceType.HIDDEN -> MotionType.MOVE_FADE_OUT
+                    BoardPieceType.HIDDEN to BoardPieceType.INITIAL -> MotionType.MOVE_FADE_IN
+                    BoardPieceType.HIDDEN to BoardPieceType.HIDDEN -> MotionType.FADE_IN_MOVE_FADE_OUT
+                    else -> new.motionType
+                }
+            }
+            new.copy(motionType = motionType)
+        }
+
+        return result.map { item ->
+            if (item.motionType != MotionType.FADE_IN_MOVE_FADE_OUT) return@map item
+            val list = item.piecesWithAnimation(result)
+            item.copy(
+                motionType = if (list.isEmpty() || list.lastOrNull()?.memberId == item.memberId) {
+                    item.motionType
+                } else {
+                    MotionType.HIDE
+                }
+            )
+        }
+    }
+
+    private fun BoardPiece.piecesWithAnimation(targetList: List<BoardPiece>): List<BoardPiece> {
+        return targetList.filter {
+            it.index == this.index && it.motionType in setOf(
+                MotionType.FADE_IN_MOVE_FADE_OUT,
+                MotionType.MOVE
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 주요 내용
- 인증 여부에 따른 애니메이션 -> 상태 기반 애니메이션
- 이전 상태가 없는 경우(ViewModel 초기화 후 최초로 데이터 불러올 때)에는 보드판에 캐릭터를 바로 보여주고
  이전 상태가 있는 경우, 이전 상태와 새로 불러온 상태를 비교하여 캐릭터의 보드칸 위치가 변경되는 경우 애니메이션과 함께 이동을 합니다.
- 각 캐릭터마다 애니메이션이 적용되어 동시에 여러 캐릭터들이 움직일 수도 있습니다.
- 애니메이션과 아이템 획득 다이얼로그를 상태가 변경되었는지에 따라 보여주기 때문에 버그였던 중복 처리 문제도 해결하였습니다.


![Screen_Recording_20241027_112213-ezgif com-resize (1)](https://github.com/user-attachments/assets/7c112f6f-55ae-4f54-bbd7-23a65252b54a)

