### PR TITLE
사진 인증 스토리 열람 API 연동

### DIFF
--- a/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/board/mapper/MissionMapper.kt
+++ b/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/board/mapper/MissionMapper.kt
@@ -69,7 +69,9 @@ fun MissionVerificationResponse.toModel() : MissionVerification {
         nickname = nickname,
         characterType = characterType.toModel(),
         imageUrl = imageUrl,
-        verifiedAt = verifiedAt
+        verifiedAt = verifiedAt,
+        viewedAt = viewedAt,
+        missionVerificationId = missionVerificationId
     )
 }
 

--- a/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/board/repository/MissionRepositoryImpl.kt
+++ b/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/board/repository/MissionRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.goalpanzi.mission_mate.core.domain.mission.model.MissionRank
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerification
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerifications
 import com.goalpanzi.mission_mate.core.domain.mission.repository.MissionRepository
+import com.goalpanzi.mission_mate.core.network.model.request.MissionVerificationsViewRequest
 import com.goalpanzi.mission_mate.core.network.service.MissionService
 import kotlinx.coroutines.flow.Flow
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -74,6 +75,12 @@ class MissionRepositoryImpl @Inject constructor(
         number: Int
     ): DomainResult<MissionVerification> = handleResult {
         missionService.getMyMissionVerification(missionId, number)
+    }.convert {
+        it.toModel()
+    }
+
+    override suspend fun viewVerification(missionVerificationId: Long): DomainResult<MissionVerification> = handleResult {
+        missionService.viewVerification(MissionVerificationsViewRequest(missionVerificationId))
     }.convert {
         it.toModel()
     }

--- a/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/model/MissionVerification.kt
+++ b/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/model/MissionVerification.kt
@@ -6,5 +6,7 @@ data class MissionVerification(
     val nickname : String,
     val characterType : CharacterType = CharacterType.RABBIT,
     val imageUrl : String = "",
-    val verifiedAt : String = ""
+    val verifiedAt : String = "",
+    val missionVerificationId : Long = 0,
+    val viewedAt : String = ""
 )

--- a/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/repository/MissionRepository.kt
+++ b/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/repository/MissionRepository.kt
@@ -24,6 +24,8 @@ interface MissionRepository  {
 
     suspend fun getMyMissionVerification(missionId: Long, number : Int) : DomainResult<MissionVerification>
 
+    suspend fun viewVerification(missionVerificationId : Long) : DomainResult<MissionVerification>
+
     fun clearMissionData() : Flow<Unit>
     fun setIsMissionJoined(data: Boolean) : Flow<Unit>
     fun getIsMissionJoined() : Flow<Boolean?>

--- a/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/usecase/ViewVerificationUseCase.kt
+++ b/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/usecase/ViewVerificationUseCase.kt
@@ -1,0 +1,17 @@
+package com.goalpanzi.mission_mate.core.domain.mission.usecase
+
+import com.goalpanzi.mission_mate.core.domain.common.DomainResult
+import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerification
+import com.goalpanzi.mission_mate.core.domain.mission.repository.MissionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class ViewVerificationUseCase @Inject constructor(
+    private val missionRepository: MissionRepository
+) {
+    operator fun invoke(missionVerificationId: Long) : Flow<DomainResult<MissionVerification>> = flow {
+        emit(missionRepository.viewVerification(missionVerificationId))
+    }
+}
+

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/request/MissionVerificationsViewRequest.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/request/MissionVerificationsViewRequest.kt
@@ -1,0 +1,8 @@
+package com.goalpanzi.mission_mate.core.network.model.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MissionVerificationsViewRequest(
+    val missionVerificationId : Long
+)

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/response/MissionVerificationResponse.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/response/MissionVerificationResponse.kt
@@ -7,5 +7,7 @@ data class MissionVerificationResponse(
     val nickname : String,
     val characterType : CharacterTypeResponse =CharacterTypeResponse.RABBIT,
     val imageUrl : String = "",
-    val verifiedAt : String = ""
+    val verifiedAt : String = "",
+    val missionVerificationId : Long = 0,
+    val viewedAt : String = ""
 )

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/service/MissionService.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/service/MissionService.kt
@@ -1,5 +1,6 @@
 package com.goalpanzi.mission_mate.core.network.service
 
+import com.goalpanzi.mission_mate.core.network.model.request.MissionVerificationsViewRequest
 import com.goalpanzi.mission_mate.core.network.model.response.MissionBoardsResponse
 import com.goalpanzi.mission_mate.core.network.model.response.MissionDetailResponse
 import com.goalpanzi.mission_mate.core.network.model.response.MissionRankResponse
@@ -7,6 +8,7 @@ import com.goalpanzi.mission_mate.core.network.model.response.MissionVerificatio
 import com.goalpanzi.mission_mate.core.network.model.response.MissionVerificationsResponse
 import okhttp3.MultipartBody
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
@@ -31,6 +33,11 @@ interface MissionService {
     suspend fun getMissionVerifications(
         @Path("missionId") missionId: Long
     ) : Response<MissionVerificationsResponse>
+
+    @POST("/api/missions/verifications/view")
+    suspend fun viewVerification(
+        @Body body : MissionVerificationsViewRequest
+    ) : Response<MissionVerificationResponse>
 
     @DELETE("/api/missions/{missionId}")
     suspend fun deleteMission(

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
@@ -98,7 +98,10 @@ fun UserStoryItem(
                 .then(
                     if (userStory.isVerified) {
                         Modifier
-                            .border(3.dp, OrangeGradient_FFFF5F3C_FFFFAE50, CircleShape)
+                            .then(
+                                if(userStory.isViewed) Modifier.border(3.dp, ColorWhite_FFFFFFFF, CircleShape)
+                                else Modifier.border(3.dp, OrangeGradient_FFFF5F3C_FFFFAE50, CircleShape)
+                            )
                             .clickable(
                                 interactionSource = MutableInteractionSource(),
                                 indication = null,
@@ -106,8 +109,8 @@ fun UserStoryItem(
                             )
                     } else {
                         Modifier
-                            .border(3.dp, ColorWhite_FFFFFFFF, CircleShape)
-                            .alpha(if (userStory.isMe) 1f else 0.5f)
+                            .border(3.dp, ColorWhite_FFFFFFFF.copy(alpha = userStory.userStoryAlpha), CircleShape)
+                            .alpha(userStory.userStoryAlpha)
                     }
                 )
                 .paint(
@@ -163,7 +166,31 @@ private fun VerifiedUserStoryItemPreview() {
                 characterUiModelType = CharacterUiModel.CAT,
                 imageUrl = "",
                 isVerified = true,
-                verifiedAt = ""
+                verifiedAt = "",
+                viewedAt = "",
+                missionVerificationId = 0
+            ),
+            onClickStory = {
+
+            }
+        )
+    }
+}
+
+
+@Preview
+@Composable
+private fun VerifiedViewedUserStoryItemPreview() {
+    MissionmateTheme {
+        UserStoryItem(
+            userStory = UserStory(
+                nickname = "닉네임",
+                characterUiModelType = CharacterUiModel.CAT,
+                imageUrl = "",
+                isVerified = true,
+                verifiedAt = "",
+                viewedAt = "2024-10-31T09:48:18.399Z",
+                missionVerificationId = 0
             ),
             onClickStory = {
 
@@ -182,7 +209,9 @@ private fun NotVerifiedUserStoryItemPreview() {
                 characterUiModelType = CharacterUiModel.CAT,
                 imageUrl = "",
                 isVerified = false,
-                verifiedAt = ""
+                verifiedAt = "",
+                viewedAt = "",
+                missionVerificationId = 0
             ),
             onClickStory = {
 
@@ -203,7 +232,31 @@ private fun MyVerifiedUserStoryItemPreview() {
                 imageUrl = "",
                 isVerified = true,
                 verifiedAt = "",
-                isMe = true
+                isMe = true,
+                viewedAt = "",
+                missionVerificationId = 0
+            ),
+            onClickStory = {
+
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun MyVerifiedViewedUserStoryItemPreview() {
+    MissionmateTheme {
+        UserStoryItem(
+            userStory = UserStory(
+                nickname = "닉네임",
+                characterUiModelType = CharacterUiModel.CAT,
+                imageUrl = "",
+                isVerified = true,
+                verifiedAt = "",
+                isMe = true,
+                viewedAt = "2024-10-31T09:48:18.399Z",
+                missionVerificationId = 0
             ),
             onClickStory = {
 
@@ -223,7 +276,9 @@ private fun MyNotVerifiedUserStoryItemPreview() {
                 imageUrl = "",
                 isVerified = false,
                 verifiedAt = "",
-                isMe = true
+                isMe = true,
+                viewedAt = "",
+                missionVerificationId = 0
             ),
             onClickStory = {
 

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
@@ -109,8 +109,9 @@ fun UserStoryItem(
                             )
                     } else {
                         Modifier
-                            .border(3.dp, ColorWhite_FFFFFFFF.copy(alpha = userStory.userStoryAlpha), CircleShape)
                             .alpha(userStory.userStoryAlpha)
+                            .border(3.dp, ColorWhite_FFFFFFFF, CircleShape)
+
                     }
                 )
                 .paint(

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/UserStory.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/UserStory.kt
@@ -2,22 +2,54 @@ package com.goalpanzi.mission_mate.feature.board.model
 
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerification
 
+enum class UserStoryType {
+    COLORED,
+    TRANSPARENT,
+    NORMAL
+}
 
 data class UserStory(
-    val nickname : String,
-    val characterUiModelType : CharacterUiModel,
-    val imageUrl : String,
-    val isVerified : Boolean,
-    val isMe : Boolean = false,
-    val verifiedAt : String
-)
+    val nickname: String,
+    val characterUiModelType: CharacterUiModel,
+    val imageUrl: String,
+    val isVerified: Boolean,
+    val isMe: Boolean = false,
+    val verifiedAt: String,
+    val viewedAt: String,
+    val missionVerificationId: Long
+) {
+    val isViewed = viewedAt.isNotEmpty()
 
-fun MissionVerification.toUserStory(isMe: Boolean = false) : UserStory =
+    val userStoryType: UserStoryType = if (isVerified) {
+        if (isViewed) {
+            UserStoryType.NORMAL
+        } else {
+            UserStoryType.COLORED
+        }
+    } else {
+        if (isMe) {
+            UserStoryType.NORMAL
+        } else {
+            UserStoryType.TRANSPARENT
+        }
+    }
+
+    val userStoryAlpha = when (userStoryType) {
+        UserStoryType.TRANSPARENT -> 0.3f
+        else -> 1f
+    }
+
+
+}
+
+fun MissionVerification.toUserStory(isMe: Boolean = false): UserStory =
     UserStory(
         nickname = nickname,
         characterUiModelType = characterType.toCharacterUiModel(),
         imageUrl = imageUrl,
         isVerified = imageUrl.isNotEmpty(),
         isMe = isMe,
-        verifiedAt = verifiedAt
+        verifiedAt = verifiedAt,
+        viewedAt = viewedAt,
+        missionVerificationId = missionVerificationId
     )

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/UserStory.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/UserStory.kt
@@ -35,7 +35,7 @@ data class UserStory(
     }
 
     val userStoryAlpha = when (userStoryType) {
-        UserStoryType.TRANSPARENT -> 0.3f
+        UserStoryType.TRANSPARENT -> 0.4f
         else -> 1f
     }
 

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
@@ -207,7 +207,12 @@ fun BoardRoute(
         onClickTooltip = {
             viewModel.setViewedTooltip()
         },
-        onClickStory = onClickStory,
+        onClickStory = { story ->
+            onClickStory(story)
+            if(story.isVerified && !story.isViewed) {
+                viewModel.viewVerification(story.missionVerificationId)
+            }
+        },
         onClickMyVerificationBoardBlock = {
             viewModel.getMyMissionVerification(it)
         }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -308,7 +308,9 @@ class BoardViewModel @Inject constructor(
                                 imageUrl = it.data.imageUrl,
                                 isVerified = true,
                                 nickname = it.data.nickname,
-                                verifiedAt = it.data.verifiedAt
+                                verifiedAt = it.data.verifiedAt,
+                                viewedAt = it.data.viewedAt,
+                                missionVerificationId = it.data.missionVerificationId
                             )
                         )
                     }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -11,6 +11,7 @@ import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionVerificationsUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMyMissionVerificationUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.VerifyMissionUseCase
+import com.goalpanzi.mission_mate.core.domain.mission.usecase.ViewVerificationUseCase
 import com.goalpanzi.mission_mate.core.domain.setting.usecase.GetViewedTooltipUseCase
 import com.goalpanzi.mission_mate.core.domain.setting.usecase.SetViewedTooltipUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
@@ -38,6 +39,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.stateIn
@@ -58,6 +60,7 @@ class BoardViewModel @Inject constructor(
     private val setViewedTooltipUseCase: SetViewedTooltipUseCase,
     private val verifyMissionUseCase: VerifyMissionUseCase,
     private val getMyMissionVerificationUseCase : GetMyMissionVerificationUseCase,
+    private val viewVerificationUseCase: ViewVerificationUseCase
 ) : ViewModel() {
 
     val missionId: Long = savedStateHandle.get<Long>("missionId")!!
@@ -326,4 +329,12 @@ class BoardViewModel @Inject constructor(
         }
     }
 
+    fun viewVerification(missionVerificationId : Long){
+        viewModelScope.launch {
+            viewVerificationUseCase(missionVerificationId)
+               .collectLatest {
+                   getMissionVerification()
+                }
+        }
+    }
 }


### PR DESCRIPTION
## 주요 내용
- 미션 보드 화면에서 사진 인증한 스토리 열람 API 추가 및 연동하였습니다.
- 인증 목록에서 인증을 했고, 아직 열람 기록이 없는 경우 해당 API 를 호출하도록 하였습니다.
- 고민했던 부분은 미열람한 스토리 클릭 시 사진을 보여주는 것과 API 호출을 자연스럽게 구현을 하려고 하였고,
  BoardScreen에서 UserStoryScreen 로 화면이 넘어가더라도 BoardViewModel 가 존재하고 있기 때문에 
 BoardViewModel 에서는 API 호출하고 화면은 UserStoryScreen로 넘어가도록 구현하였습니다.

![KakaoTalk_Video_2024-10-31-22-38-39-ezgif com-resize](https://github.com/user-attachments/assets/1b08b3dd-d372-4529-85f1-1d27d34fe9ac)
