### PR TITLE
미션 상태 - 인원 미달, 종료 대기 대응

### DIFF
--- a/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/board/repository/MissionRepositoryImpl.kt
+++ b/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/board/repository/MissionRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.goalpanzi.mission_mate.core.domain.mission.model.MissionRank
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerification
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerifications
 import com.goalpanzi.mission_mate.core.domain.mission.repository.MissionRepository
+import com.goalpanzi.mission_mate.core.network.model.request.CompleteMissionRequest
 import com.goalpanzi.mission_mate.core.network.service.MissionService
 import kotlinx.coroutines.flow.Flow
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -76,6 +77,12 @@ class MissionRepositoryImpl @Inject constructor(
         missionService.getMyMissionVerification(missionId, number)
     }.convert {
         it.toModel()
+    }
+
+    override suspend fun completeMission(missionId: Long): DomainResult<Unit>  = handleResult {
+        missionService.completeMission(
+            CompleteMissionRequest(missionId)
+        )
     }
 
     override fun clearMissionData(): Flow<Unit> = missionDataSource.clearMissionData()

--- a/core/data/onboarding/src/main/java/com/goalpanzi/mission_mate/core/data/onboarding/mapper/OnboardingMapper.kt
+++ b/core/data/onboarding/src/main/java/com/goalpanzi/mission_mate/core/data/onboarding/mapper/OnboardingMapper.kt
@@ -1,11 +1,13 @@
 package com.goalpanzi.mission_mate.core.data.onboarding.mapper
 
 import com.goalpanzi.mission_mate.core.data.common.mapper.toModel
+import com.goalpanzi.mission_mate.core.domain.common.model.mission.MissionStatus
 import com.goalpanzi.mission_mate.core.domain.onboarding.model.CreateMissionBody
 import com.goalpanzi.mission_mate.core.domain.onboarding.model.Mission
 import com.goalpanzi.mission_mate.core.domain.onboarding.model.Missions
 import com.goalpanzi.mission_mate.core.network.model.request.CreateMissionRequest
 import com.goalpanzi.mission_mate.core.network.model.response.MissionResponse
+import com.goalpanzi.mission_mate.core.network.model.response.MissionStatusResponse
 import com.goalpanzi.mission_mate.core.network.model.response.MissionsResponse
 
 fun CreateMissionBody.toRequest() : CreateMissionRequest {
@@ -23,7 +25,7 @@ fun MissionResponse.toModel() : Mission {
     return Mission(
         missionId = missionId,
         description = description,
-        missionStatus = missionStatus
+        missionStatus = missionStatus.toModel()
     )
 }
 
@@ -35,4 +37,12 @@ fun MissionsResponse.toModel() : Missions {
             it.toModel()
         }
     )
+}
+
+fun MissionStatusResponse.toModel() : MissionStatus {
+    return try{
+        MissionStatus.valueOf(this.name)
+    }catch (e : Exception){
+        MissionStatus.COMPLETED
+    }
 }

--- a/core/data/onboarding/src/main/java/com/goalpanzi/mission_mate/core/data/onboarding/repository/OnboardingRepositoryImpl.kt
+++ b/core/data/onboarding/src/main/java/com/goalpanzi/mission_mate/core/data/onboarding/repository/OnboardingRepositoryImpl.kt
@@ -34,7 +34,7 @@ class OnboardingRepositoryImpl @Inject constructor(
             onboardingService.joinMission(JoinMissionRequest(invitationCode))
         }
 
-    override suspend fun getJoinedMissions(): DomainResult<Missions> = handleResult {
-        onboardingService.getJoinedMissions()
+    override suspend fun getJoinedMissions(filter : String): DomainResult<Missions> = handleResult {
+        onboardingService.getJoinedMissions(filter)
     }.convert { it.toModel() }
 }

--- a/core/domain/common/src/main/java/com/goalpanzi/mission_mate/core/domain/common/model/mission/MissionStatus.kt
+++ b/core/domain/common/src/main/java/com/goalpanzi/mission_mate/core/domain/common/model/mission/MissionStatus.kt
@@ -1,0 +1,17 @@
+package com.goalpanzi.mission_mate.core.domain.common.model.mission
+
+enum class MissionStatus {
+    CREATED,
+    CANCELED,
+    IN_PROGRESS,
+    DELETED,
+    PENDING_COMPLETION,
+    COMPLETED;
+
+    companion object {
+        val statusString: String = listOf(CREATED, CANCELED, IN_PROGRESS, PENDING_COMPLETION)
+            .joinToString(",") { it.name }
+    }
+}
+
+

--- a/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/repository/MissionRepository.kt
+++ b/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/repository/MissionRepository.kt
@@ -24,6 +24,8 @@ interface MissionRepository  {
 
     suspend fun getMyMissionVerification(missionId: Long, number : Int) : DomainResult<MissionVerification>
 
+    suspend fun completeMission(missionId : Long) : DomainResult<Unit>
+
     fun clearMissionData() : Flow<Unit>
     fun setIsMissionJoined(data: Boolean) : Flow<Unit>
     fun getIsMissionJoined() : Flow<Boolean?>

--- a/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/usecase/CompleteMissionUseCase.kt
+++ b/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/usecase/CompleteMissionUseCase.kt
@@ -1,0 +1,16 @@
+package com.goalpanzi.mission_mate.core.domain.mission.usecase
+
+import com.goalpanzi.mission_mate.core.domain.common.DomainResult
+import com.goalpanzi.mission_mate.core.domain.mission.repository.MissionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class CompleteMissionUseCase @Inject constructor(
+    private val missionRepository: MissionRepository
+) {
+    operator fun invoke(missionId: Long) : Flow<DomainResult<Unit>> = flow {
+        emit(missionRepository.completeMission(missionId))
+    }
+}
+

--- a/core/domain/onboarding/src/main/java/com/goalpanzi/mission_mate/core/domain/onboarding/model/Mission.kt
+++ b/core/domain/onboarding/src/main/java/com/goalpanzi/mission_mate/core/domain/onboarding/model/Mission.kt
@@ -1,7 +1,9 @@
 package com.goalpanzi.mission_mate.core.domain.onboarding.model
 
+import com.goalpanzi.mission_mate.core.domain.common.model.mission.MissionStatus
+
 data class Mission(
     val missionId : Long,
     val description : String,
-    val missionStatus : String
+    val missionStatus : MissionStatus
 )

--- a/core/domain/onboarding/src/main/java/com/goalpanzi/mission_mate/core/domain/onboarding/repository/OnboardingRepository.kt
+++ b/core/domain/onboarding/src/main/java/com/goalpanzi/mission_mate/core/domain/onboarding/repository/OnboardingRepository.kt
@@ -18,5 +18,5 @@ interface OnboardingRepository  {
         invitationCode: String
     ) : DomainResult<Unit>
 
-    suspend fun getJoinedMissions() : DomainResult<Missions>
+    suspend fun getJoinedMissions(filter : String) : DomainResult<Missions>
 }

--- a/core/domain/onboarding/src/main/java/com/goalpanzi/mission_mate/core/domain/onboarding/usecase/GetJoinedMissionsUseCase.kt
+++ b/core/domain/onboarding/src/main/java/com/goalpanzi/mission_mate/core/domain/onboarding/usecase/GetJoinedMissionsUseCase.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class GetJoinedMissionsUseCase @Inject constructor(
     private val onboardingRepository: OnboardingRepository
 ) {
-    operator fun invoke(): Flow<DomainResult<Missions>> = flow {
-        emit(onboardingRepository.getJoinedMissions())
+    operator fun invoke(filter : String): Flow<DomainResult<Missions>> = flow {
+        emit(onboardingRepository.getJoinedMissions(filter))
     }
 }

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/request/CompleteMissionRequest.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/request/CompleteMissionRequest.kt
@@ -1,0 +1,8 @@
+package com.goalpanzi.mission_mate.core.network.model.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CompleteMissionRequest(
+    val missionId : Long
+)

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/response/MissionResponse.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/response/MissionResponse.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 data class MissionResponse(
     val missionId : Long,
     val description : String,
-    val missionStatus : String
+    val missionStatus : MissionStatusResponse
 )

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/response/MissionStatusResponse.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/response/MissionStatusResponse.kt
@@ -1,0 +1,10 @@
+package com.goalpanzi.mission_mate.core.network.model.response
+
+enum class MissionStatusResponse {
+    CREATED,
+    CANCELED,
+    IN_PROGRESS,
+    DELETED,
+    PENDING_COMPLETION,
+    COMPLETED
+}

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/service/MissionService.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/service/MissionService.kt
@@ -1,5 +1,6 @@
 package com.goalpanzi.mission_mate.core.network.service
 
+import com.goalpanzi.mission_mate.core.network.model.request.CompleteMissionRequest
 import com.goalpanzi.mission_mate.core.network.model.response.MissionBoardsResponse
 import com.goalpanzi.mission_mate.core.network.model.response.MissionDetailResponse
 import com.goalpanzi.mission_mate.core.network.model.response.MissionRankResponse
@@ -7,6 +8,7 @@ import com.goalpanzi.mission_mate.core.network.model.response.MissionVerificatio
 import com.goalpanzi.mission_mate.core.network.model.response.MissionVerificationsResponse
 import okhttp3.MultipartBody
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
@@ -54,4 +56,9 @@ interface MissionService {
         @Path("missionId") missionId: Long,
         @Path("number") number: Int
     ) : Response<MissionVerificationResponse>
+
+    @POST("/api/mission-members/complete")
+    suspend fun completeMission(
+        @Body request: CompleteMissionRequest
+    ): Response<Unit>
 }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
@@ -101,8 +101,8 @@ fun NavGraphBuilder.boardFinishNavGraph(
         arguments = listOf(navArgument(missionIdArg) { type = NavType.LongType })
     ) {
         BoardFinishRoute(
-            onClickSetting = onClickSetting,
-            onClickOk = onClickOk
+            onSettingClick = onClickSetting,
+            onOkClick = onClickOk
         )
     }
 }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishScreen.kt
@@ -208,7 +208,7 @@ fun BoardFinishScreen(
                         .fillMaxWidth()
                         .wrapContentHeight(),
                     buttonType = MissionMateButtonType.ACTIVE,
-                    textId = com.goalpanzi.mission_mate.feature.onboarding.R.string.start,
+                    textId = com.goalpanzi.mission_mate.feature.onboarding.R.string.confirm,
                     onClick = onClickOk
                 )
             }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishScreen.kt
@@ -4,6 +4,7 @@ import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,8 +19,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -51,8 +54,8 @@ import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun BoardFinishRoute(
-    onClickSetting: () -> Unit,
-    onClickOk : () -> Unit,
+    onSettingClick: () -> Unit,
+    onOkClick : () -> Unit,
     modifier: Modifier = Modifier,
     viewModel : BoardFinishViewModel = hiltViewModel()
 ) {
@@ -60,6 +63,9 @@ fun BoardFinishRoute(
     val rank by viewModel.rank.collectAsStateWithLifecycle()
     val userProfile by viewModel.profile.collectAsStateWithLifecycle()
     var showProgress by rememberSaveable { mutableStateOf(false) }
+    val isLoading by remember {
+        derivedStateOf { rank == null || userProfile == null || showProgress }
+    }
 
     LaunchedEffect(key1 = Unit) {
         viewModel.getRankByMissionId()
@@ -75,7 +81,7 @@ fun BoardFinishRoute(
             when(it){
                 CompleteMissionEvent.Success -> {
                     showProgress = false
-                    onClickOk()
+                    onOkClick()
                 }
                 CompleteMissionEvent.Error -> {
                     showProgress = false
@@ -92,32 +98,23 @@ fun BoardFinishRoute(
         }
     }
 
-
-    if(rank != null && userProfile != null && !showProgress){
-        BoardFinishScreen(
-            modifier = modifier,
-            rank = rank!!,
-            characterUiModel = userProfile!!.characterType.toCharacterUiModel(),
-            onClickOk = viewModel::completeMission,
-            onClickSetting = onClickSetting
-        )
-    }else {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ){
-            CircularProgressIndicator()
-        }
-    }
-
+    BoardFinishScreen(
+        modifier = modifier,
+        rank = rank,
+        isLoading = isLoading,
+        characterUiModel = userProfile?.characterType?.toCharacterUiModel(),
+        onOkClick = viewModel::completeMission,
+        onSettingClick = onSettingClick
+    )
 }
 
 @Composable
 fun BoardFinishScreen(
-    characterUiModel : CharacterUiModel,
-    rank : Int,
-    onClickSetting: () -> Unit,
-    onClickOk : () -> Unit,
+    characterUiModel : CharacterUiModel?,
+    rank : Int?,
+    isLoading : Boolean,
+    onSettingClick: () -> Unit,
+    onOkClick : () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -141,7 +138,7 @@ fun BoardFinishScreen(
                 navigationType = NavigationType.NONE,
                 rightActionButtons = {
                     IconButton(
-                        onClick = onClickSetting,
+                        onClick = onSettingClick,
                         modifier = Modifier.wrapContentSize()
                     ) {
                         Icon(
@@ -153,79 +150,112 @@ fun BoardFinishScreen(
                 },
                 containerColor = Color.Transparent
             )
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-                contentAlignment = Alignment.BottomCenter
-            ){
-                Box(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentAlignment = Alignment.Center
-                ){
-                    StableImage(
-                        modifier = Modifier.fillMaxWidth(),
-                        drawableResId = R.drawable.img_mission_finish,
-                        contentScale = ContentScale.Crop
-                    )
-                    StableImage(
-                        modifier = Modifier
-                            .fillMaxWidth(212f / 390f)
-                            .aspectRatio(1f),
-                        drawableResId = characterUiModel.imageId
-                    )
-                }
-                LottieImage(
-                    modifier = Modifier.wrapContentSize().align(Alignment.Center),
-                    lottieRes = com.goalpanzi.mission_mate.core.designsystem.R.raw.animation_celebration
-                )
-            }
-            Column(
-                modifier = Modifier.background(color = ColorWhite_FFFFFFFF),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    modifier = Modifier.padding(top = 8.dp),
-                    text = stringResource(id = R.string.board_finish_rank, rank),
-                    color = ColorGray1_FF404249,
-                    style = MissionMateTypography.heading_xl_bold
-                )
-                Text(
-                    modifier = Modifier.padding(top = 20.dp, bottom = 4.dp),
-                    text = stringResource(id = R.string.board_finish_description),
-                    color = ColorGray1_FF404249,
-                    style = MissionMateTypography.title_xl_bold
-                )
-                Text(
-                    text = stringResource(id = R.string.board_finish_sub_description),
-                    color = ColorGray1_FF404249,
-                    style = MissionMateTypography.body_xl_regular,
-                    textAlign = TextAlign.Center
-                )
-                MissionMateTextButton(
-                    modifier = Modifier
-                        .padding(bottom = 36.dp, start = 24.dp, end = 24.dp, top = 68.dp)
-                        .fillMaxWidth()
-                        .wrapContentHeight(),
-                    buttonType = MissionMateButtonType.ACTIVE,
-                    textId = com.goalpanzi.mission_mate.feature.onboarding.R.string.confirm,
-                    onClick = onClickOk
-                )
-            }
-
+            BoardFinishCharacter(
+                characterUiModel = characterUiModel
+            )
+            BoardFinishBottom(
+                rank = rank,
+                onOkClick = onOkClick
+            )
+        }
+        if(isLoading){
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center)
+            )
         }
     }
 
+}
+
+@Composable
+fun ColumnScope.BoardFinishCharacter(
+    characterUiModel: CharacterUiModel?,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .weight(1f),
+        contentAlignment = Alignment.BottomCenter
+    ){
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ){
+            StableImage(
+                modifier = Modifier.fillMaxWidth(),
+                drawableResId = R.drawable.img_mission_finish,
+                contentScale = ContentScale.Crop
+            )
+            characterUiModel?.let {
+                StableImage(
+                    modifier = Modifier
+                        .fillMaxWidth(212f / 390f)
+                        .aspectRatio(1f),
+                    drawableResId = characterUiModel.imageId
+                )
+            }
+        }
+        LottieImage(
+            modifier = Modifier
+                .wrapContentSize()
+                .align(Alignment.Center),
+            lottieRes = com.goalpanzi.mission_mate.core.designsystem.R.raw.animation_celebration
+        )
+    }
+}
+
+@Composable
+fun BoardFinishBottom(
+    rank: Int?,
+    onOkClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.background(color = ColorWhite_FFFFFFFF),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            modifier = Modifier.padding(top = 8.dp),
+            text = rank?.let { stringResource(id = R.string.board_finish_rank, rank) } ?: "",
+            color = ColorGray1_FF404249,
+            style = MissionMateTypography.heading_xl_bold
+        )
+        Text(
+            modifier = Modifier.padding(top = 20.dp, bottom = 4.dp),
+            text = stringResource(id = R.string.board_finish_description),
+            color = ColorGray1_FF404249,
+            style = MissionMateTypography.title_xl_bold
+        )
+        Text(
+            text = stringResource(id = R.string.board_finish_sub_description),
+            color = ColorGray1_FF404249,
+            style = MissionMateTypography.body_xl_regular,
+            textAlign = TextAlign.Center
+        )
+        MissionMateTextButton(
+            modifier = Modifier
+                .padding(bottom = 36.dp, start = 24.dp, end = 24.dp, top = 68.dp)
+                .fillMaxWidth()
+                .wrapContentHeight(),
+            buttonType = MissionMateButtonType.ACTIVE,
+            textId = com.goalpanzi.mission_mate.feature.onboarding.R.string.confirm,
+            onClick = onOkClick
+        )
+    }
 }
 
 @Preview
 @Composable
 private fun PreviewBoardFinishScreen() {
     BoardFinishScreen(
-        characterUiModel = CharacterUiModel.RABBIT,
+        characterUiModel = null,
         rank = 10,
-        onClickSetting = {},
-        onClickOk = {}
+        isLoading = false,
+        onSettingClick = {},
+        onOkClick = {}
     )
 
 }
+
+

--- a/feature/board/src/main/res/values/strings.xml
+++ b/feature/board/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="board_mission_detail_delete">삭제하기</string>
 
     <string name="board_mission_not_exist">미션을 불러올 수 없습니다.</string>
+    <string name="board_complete_error">에러가 발생하였습니다.</string>
 
     <string name="ok">확인</string>
     <string name="cancel">취소</string>


### PR DESCRIPTION
## 주요 내용
- 미션 상태를 나타내는 MissionStatus enum class를 추가하였습니다.
- /api/mission-members/me 호출 시 CREATED, CANCELED, IN_PROGRESS, PENDING_COMPLETION 을 필터 값으로 두고 CREATED, IN_PROGRESS 은 보드 화면, CANCELED은 보드 화면 후 인원 미달 다이얼로그, PENDING_COMPLETION 은 미션 종료 화면으로 이동합니다.
- 미션 종료 화면(결승선 화면)에서 확인 버튼 클릭 시 미션 완료 API를 호출하여 미션 상태를 완료로 변경 요청 합니다.
![KakaoTalk_Video_2024-11-09-00-11-33-ezgif com-resize](https://github.com/user-attachments/assets/7ca6a38b-d649-4b6c-8ac1-83bad20e1762)
