### PR TITLE
보드판 첫 칸 클릭 이벤트 차단

### DIFF
--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/Block.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/Block.kt
@@ -125,15 +125,9 @@ fun BlockImage(
         Spacer(modifier = modifier)
     }else {
         StableImage(
-            modifier = modifier.then(
-                if (isStartedMission && isPassed) {
-                    Modifier.clickable {
-                        onClickPassedBlock(index)
-                    }
-                } else {
-                    Modifier
-                }
-            ),
+            modifier = modifier.clickable(isStartedMission && isPassed && index != 0){
+                onClickPassedBlock(index)
+            } ,
             drawableResId = drawableRes,
             contentScale = ContentScale.FillWidth
         )


### PR DESCRIPTION
## 주요 내용
- 보드판 첫 칸의 경우 인증 내역이 없음에도 클릭 시 API를 호출하고 있어서 첫 칸인 경우 클릭 이벤트를 차단하였습니다.