### PR TITLE
보드판 화면에서 미션 조회 실패 시 무한 반복 오류 수정

### DIFF
--- a/build-logic/src/main/kotlin/missionmate.android.feature.gradle.kts
+++ b/build-logic/src/main/kotlin/missionmate.android.feature.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(project(":core:domain:mission"))
     implementation(project(":core:domain:common"))
     implementation(project(":core:domain:auth"))
+    implementation(project(":core:domain:onboarding"))
     implementation(project(":core:ui"))
 
 }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/dialog/InvalidMissionErrorDialog.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/dialog/InvalidMissionErrorDialog.kt
@@ -1,0 +1,26 @@
+package com.goalpanzi.mission_mate.feature.board.component.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.window.DialogProperties
+import com.goalpanzi.mission_mate.core.designsystem.component.MissionMateDialog
+import com.goalpanzi.mission_mate.feature.board.R
+
+@Composable
+fun InvalidMissionErrorDialog(
+    onDismissRequest: () -> Unit,
+    onClickOk: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    MissionMateDialog(
+        titleId = R.string.board_mission_not_exist,
+        onDismissRequest = onDismissRequest,
+        onClickOk = onClickOk,
+        okTextId = R.string.retry,
+        dialogProperties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        )
+    )
+}

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/MissionError.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/MissionError.kt
@@ -1,5 +1,5 @@
 package com.goalpanzi.mission_mate.feature.board.model
 
 enum class MissionError {
-    NOT_EXIST,
+    NOT_EXIST, INVALID_MISSION
 }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -70,7 +70,7 @@ class BoardViewModel @Inject constructor(
 
     val viewedToolTip: StateFlow<Boolean> = getViewedTooltipUseCase().stateIn(
         viewModelScope,
-        started = SharingStarted.WhileSubscribed(500),
+        started = SharingStarted.WhileSubscribed(5_000),
         initialValue = true
     )
 
@@ -108,7 +108,7 @@ class BoardViewModel @Inject constructor(
             memberId == mission.missionDetail.hostMemberId
         }.stateIn(
             viewModelScope,
-            started = SharingStarted.WhileSubscribed(500),
+            started = SharingStarted.WhileSubscribed(5_000),
             initialValue = false
         )
 
@@ -121,7 +121,7 @@ class BoardViewModel @Inject constructor(
             getMissionState(missionBoard, mission, missionVerification)
         }.stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(500),
+            started = SharingStarted.WhileSubscribed(5_000),
             initialValue = MissionState.LOADING
         )
     private val _boardRewardEvent = MutableSharedFlow<BoardReward?>()
@@ -194,7 +194,7 @@ class BoardViewModel @Inject constructor(
 
                     else -> {
                         _missionBoardUiModel.emit(MissionBoardUiModel.Error)
-                        if(!isSameAsLastMission()) _missionError.emit(MissionError.NOT_EXIST)
+                        handleMissionError(isSameAsLastMission())
                     }
                 }
             }
@@ -211,7 +211,7 @@ class BoardViewModel @Inject constructor(
 
                 else -> {
                     _missionUiModel.emit(MissionUiModel.Error)
-                    if(!isSameAsLastMission()) _missionError.emit(MissionError.NOT_EXIST)
+                    handleMissionError(isSameAsLastMission())
                 }
             }
         }
@@ -228,7 +228,7 @@ class BoardViewModel @Inject constructor(
 
                 else -> {
                     _missionVerificationUiModel.emit(MissionVerificationUiModel.Error)
-                    if(!isSameAsLastMission()) _missionError.emit(MissionError.NOT_EXIST)
+                    handleMissionError(isSameAsLastMission())
                 }
             }
         }
@@ -291,6 +291,15 @@ class BoardViewModel @Inject constructor(
                     getMissionVerification()
                 }
         }
+    }
+
+    fun resetMissionError() {
+        _missionError.value = null
+    }
+
+    private suspend fun handleMissionError(isSameAsLastMission : Boolean){
+        if(isSameAsLastMission) _missionError.emit(MissionError.INVALID_MISSION)
+        else _missionError.emit(MissionError.NOT_EXIST)
     }
 
     private suspend fun isSameAsLastMission(): Boolean {

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -4,14 +4,15 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.goalpanzi.mission_mate.core.domain.common.DomainResult
+import com.goalpanzi.mission_mate.core.domain.common.model.mission.MissionStatus.Companion.statusString
 import com.goalpanzi.mission_mate.core.domain.mission.model.BoardReward
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.DeleteMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionBoardsUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionVerificationsUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMyMissionVerificationUseCase
-import com.goalpanzi.mission_mate.core.domain.mission.usecase.VerifyMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.ViewVerificationUseCase
+import com.goalpanzi.mission_mate.core.domain.onboarding.usecase.GetJoinedMissionsUseCase
 import com.goalpanzi.mission_mate.core.domain.setting.usecase.GetViewedTooltipUseCase
 import com.goalpanzi.mission_mate.core.domain.setting.usecase.SetViewedTooltipUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
@@ -43,6 +44,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -59,8 +61,8 @@ class BoardViewModel @Inject constructor(
     private val deleteMissionUseCase: DeleteMissionUseCase,
     private val profileUseCase: ProfileUseCase,
     private val setViewedTooltipUseCase: SetViewedTooltipUseCase,
-    private val verifyMissionUseCase: VerifyMissionUseCase,
-    private val getMyMissionVerificationUseCase : GetMyMissionVerificationUseCase,
+    private val getJoinedMissionsUseCase: GetJoinedMissionsUseCase,
+    private val getMyMissionVerificationUseCase: GetMyMissionVerificationUseCase,
     private val viewVerificationUseCase: ViewVerificationUseCase
 ) : ViewModel() {
 
@@ -157,7 +159,13 @@ class BoardViewModel @Inject constructor(
                     is DomainResult.Success -> {
                         val myMemberId = getCachedMemberIdUseCase().first()
 
-                        _missionBoardUiModel.emit(MissionBoardUiModel.Success(it.data.toUiModel(myMemberId)))
+                        _missionBoardUiModel.emit(
+                            MissionBoardUiModel.Success(
+                                it.data.toUiModel(
+                                    myMemberId
+                                )
+                            )
+                        )
 
                         val boardPieceList =
                             it.data.toUiModel(myMemberId).toBoardPieces(profileUseCase.getProfile())
@@ -166,7 +174,7 @@ class BoardViewModel @Inject constructor(
                             _boardPieces.emit(boardPieceList)
                         } else {
                             val isMoved =
-                                boardPieces.value.find { it.isMe }?.index?.plus(1) ==  boardPieceList.find { it.isMe }?.index
+                                boardPieces.value.find { it.isMe }?.index?.plus(1) == boardPieceList.find { it.isMe }?.index
 
                             val newList = PieceManager.getBoardPieces(
                                 boardPieces.value,
@@ -175,7 +183,7 @@ class BoardViewModel @Inject constructor(
                             _boardPieces.emit(
                                 newList
                             )
-                            if(isMoved){
+                            if (isMoved) {
                                 delay(550)
                                 _boardRewardEvent.emit(
                                     it.data.missionBoards.find { it.isMyPosition }?.reward
@@ -186,7 +194,7 @@ class BoardViewModel @Inject constructor(
 
                     else -> {
                         _missionBoardUiModel.emit(MissionBoardUiModel.Error)
-                        _missionError.emit(MissionError.NOT_EXIST)
+                        if(!isSameAsLastMission()) _missionError.emit(MissionError.NOT_EXIST)
                     }
                 }
             }
@@ -203,7 +211,7 @@ class BoardViewModel @Inject constructor(
 
                 else -> {
                     _missionUiModel.emit(MissionUiModel.Error)
-                    _missionError.emit(MissionError.NOT_EXIST)
+                    if(!isSameAsLastMission()) _missionError.emit(MissionError.NOT_EXIST)
                 }
             }
         }
@@ -220,7 +228,7 @@ class BoardViewModel @Inject constructor(
 
                 else -> {
                     _missionVerificationUiModel.emit(MissionVerificationUiModel.Error)
-                    _missionError.emit(MissionError.NOT_EXIST)
+                    if(!isSameAsLastMission()) _missionError.emit(MissionError.NOT_EXIST)
                 }
             }
         }
@@ -275,13 +283,23 @@ class BoardViewModel @Inject constructor(
             }
         }
     }
-    
-    fun viewVerification(missionVerificationId : Long){
+
+    fun viewVerification(missionVerificationId: Long) {
         viewModelScope.launch {
             viewVerificationUseCase(missionVerificationId)
-               .collectLatest {
-                   getMissionVerification()
+                .collectLatest {
+                    getMissionVerification()
                 }
+        }
+    }
+
+    private suspend fun isSameAsLastMission(): Boolean {
+        return when (val result = getJoinedMissionsUseCase(filter = statusString).firstOrNull()) {
+            is DomainResult.Success -> {
+                result.data.missions.lastOrNull()?.missionId == missionId
+            }
+
+            else -> false
         }
     }
 }

--- a/feature/board/src/main/res/values/strings.xml
+++ b/feature/board/src/main/res/values/strings.xml
@@ -53,11 +53,13 @@
     <string name="board_mission_detail_description_color_target">인증횟수(보드판 수)는 총 %d개</string>
     <string name="board_mission_detail_delete">삭제하기</string>
 
-    <string name="board_mission_not_exist">미션을 불러올 수 없습니다.</string>
+    <string name="board_mission_not_exist">미션을 불러올 수 없어요.</string>
     <string name="board_complete_error">에러가 발생하였습니다.</string>
 
     <string name="ok">확인</string>
     <string name="cancel">취소</string>
     <string name="close">닫기</string>
     <string name="upload">업로드</string>
+
+    <string name="retry">재시도</string>
 </resources>


### PR DESCRIPTION
## 주요 내용
- 보드판 화면에서 미션 조회 실패 시 무한 반복 오류가 있어 확인한 결과
  - 에러가 발생했을 경우, '진행중인 미션'의 마지막 미션과 보드판에서의 미션이 동일하면 화면 이동이 무한 반복되어 API 를 무수히 많이 호출하는 이슈가 발생하였습니다. 
- 보드판 화면의 미션 ID 와 '진행중인 미션'의 마지막 미션 ID를 비교하여 같은 경우, 무한 반복 가능성이 있기 때문에 다이얼로그를 띄워 화면전환을 막습니다.
  - 다이얼로그의 버튼을 미션 데이터 호출을 재시도할 수 있도록 하였습니다. 
  - 무한 반복 이슈를 막기위한 임시 화면이기 때문에, 이후 디자인팀과 의논하여 UI 수정이 필요할 것으로 보입니다.
- 보드판 화면의 미션 ID 와 '진행중인 미션'의 마지막 미션 ID를 비교하여 다른 경우, 온보딩 화면으로 이동합니다.


![KakaoTalk_Video_2024-11-19-01-38-41-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/a1eea172-080c-43d9-abbd-cb0d3dae0113)

