### PR TITLE
스토리 - '나' 일 때 미션 미인증 시 반투명 처리

### DIFF
--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
@@ -40,13 +40,15 @@ import com.goalpanzi.mission_mate.core.designsystem.theme.MissionMateTypography
 import com.goalpanzi.mission_mate.core.designsystem.theme.MissionmateTheme
 import com.goalpanzi.mission_mate.core.designsystem.theme.OrangeGradient_FFFF5F3C_FFFFAE50
 import com.goalpanzi.mission_mate.feature.board.model.CharacterUiModel
+import com.goalpanzi.mission_mate.feature.board.model.MissionState
 import com.goalpanzi.mission_mate.feature.board.model.UserStory
 
 @Composable
 fun BoardTopStory(
     userList: List<UserStory>,
-    modifier: Modifier = Modifier,
+    missionState : MissionState,
     onClickStory: (UserStory) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     LazyRow(
         modifier = modifier,
@@ -57,6 +59,7 @@ fun BoardTopStory(
             items(userList) { userStory ->
                 UserStoryItem(
                     userStory = userStory,
+                    isProgressMission = missionState.isVisiblePiece(),
                     onClickStory = onClickStory
                 )
             }
@@ -77,13 +80,14 @@ fun BoardTopStory(
 fun UserStoryItem(
     userStory: UserStory,
     onClickStory: (UserStory) -> Unit,
+    isProgressMission: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Box(
         modifier = modifier
             .height(98.dp)
             .widthIn(min = 70.dp)
-            .alpha(userStory.userStoryAlpha),
+            .alpha(if(!isProgressMission && userStory.isMe) 1f else userStory.userStoryAlpha),
         contentAlignment = Alignment.TopCenter
     ) {
         StableImage(
@@ -168,6 +172,7 @@ private fun VerifiedUserStoryItemPreview() {
                 viewedAt = "",
                 missionVerificationId = 0
             ),
+            isProgressMission = true,
             onClickStory = {
 
             }
@@ -190,6 +195,7 @@ private fun VerifiedViewedUserStoryItemPreview() {
                 viewedAt = "2024-10-31T09:48:18.399Z",
                 missionVerificationId = 0
             ),
+            isProgressMission = true,
             onClickStory = {
 
             }
@@ -211,6 +217,7 @@ private fun NotVerifiedUserStoryItemPreview() {
                 viewedAt = "",
                 missionVerificationId = 0
             ),
+            isProgressMission = true,
             onClickStory = {
 
             }
@@ -234,6 +241,7 @@ private fun MyVerifiedUserStoryItemPreview() {
                 viewedAt = "",
                 missionVerificationId = 0
             ),
+            isProgressMission = true,
             onClickStory = {
 
             }
@@ -256,6 +264,7 @@ private fun MyVerifiedViewedUserStoryItemPreview() {
                 viewedAt = "2024-10-31T09:48:18.399Z",
                 missionVerificationId = 0
             ),
+            isProgressMission = true,
             onClickStory = {
 
             }
@@ -278,6 +287,7 @@ private fun MyNotVerifiedUserStoryItemPreview() {
                 viewedAt = "",
                 missionVerificationId = 0
             ),
+            isProgressMission = true,
             onClickStory = {
 
             }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopStory.kt
@@ -82,7 +82,8 @@ fun UserStoryItem(
     Box(
         modifier = modifier
             .height(98.dp)
-            .widthIn(min = 70.dp),
+            .widthIn(min = 70.dp)
+            .alpha(userStory.userStoryAlpha),
         contentAlignment = Alignment.TopCenter
     ) {
         StableImage(
@@ -106,7 +107,6 @@ fun UserStoryItem(
                             )
                     } else {
                         Modifier
-                            .alpha(userStory.userStoryAlpha)
                             .border(3.dp, ColorWhite_FFFFFFFF, CircleShape)
 
                     }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopView.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/component/BoardTopView.kt
@@ -78,7 +78,8 @@ fun BoardTopView(
         BoardTopStory(
             modifier = Modifier.padding(top = 56.dp),
             userList = userList,
-            onClickStory = onClickStory
+            missionState = missionState,
+            onClickStory = onClickStory,
         )
         if(!viewedTooltip){
             if (isAddingUserEnabled) {

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/UserStory.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/UserStory.kt
@@ -27,11 +27,7 @@ data class UserStory(
             UserStoryType.COLORED
         }
     } else {
-        if (isMe) {
-            UserStoryType.NORMAL
-        } else {
-            UserStoryType.TRANSPARENT
-        }
+        UserStoryType.TRANSPARENT
     }
 
     val userStoryAlpha = when (userStoryType) {


### PR DESCRIPTION
## 주요 내용
- 기존에는 미션 보드판 - 스토리에서 '나'의 경우 반투명 처리가 없었는데,  회의에서 정해진 내용에 따라서 '나'의 경우에도 미션 미인증 시 반투명 처리하도록 하였습니다.

<img src="https://github.com/user-attachments/assets/1053a45c-9c42-425f-8f5e-295bc95d4a72" width="320"/>

