### PR TITLE
미션 데이터 API 호출 시 동시 호출

### DIFF
--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -132,9 +132,11 @@ class BoardViewModel @Inject constructor(
 
     fun fetchMissionData() {
         viewModelScope.launch {
-            getMissionBoards()
-            getMission()
-            getMissionVerification()
+            joinAll(
+                launch { getMission() },
+                launch { getMissionVerification() },
+                launch { getMissionBoards() }
+            )
         }
     }
 
@@ -142,9 +144,9 @@ class BoardViewModel @Inject constructor(
         viewModelScope.launch {
             _isRefreshLoading.emit(true)
             joinAll(
-                launch { getMissionBoards() },
                 launch { getMission() },
-                launch { getMissionVerification() }
+                launch { getMissionVerification() },
+                launch { getMissionBoards() }
             )
             _isRefreshLoading.emit(false)
         }


### PR DESCRIPTION
## 주요 내용
- 보드 화면에서 사용되는 3개의 API 호출을 기존에는 순차적으로 호출하고 있어서 장기말 이동을 할 경우 delay 때문에 다른 호출을 늦게 하는 경우가 생겨, 동시에 3개의 API 호출을 하기위해 수정하였습니다.