### PR TITLE
navigation-compose 2.8.5 마이그레이션

### DIFF
--- a/core/data/auth/src/main/java/com/goalpanzi/mission_mate/core/data/auth/AuthTokenExpirationHandler.kt
+++ b/core/data/auth/src/main/java/com/goalpanzi/mission_mate/core/data/auth/AuthTokenExpirationHandler.kt
@@ -4,6 +4,7 @@ import com.goalpanzi.mission_mate.core.datastore.datasource.AuthDataSource
 import com.goalpanzi.mission_mate.core.datastore.datasource.DefaultDataSource
 import com.goalpanzi.mission_mate.core.datastore.datasource.MissionDataSource
 import com.goalpanzi.mission_mate.core.navigation.NavigationEventHandler
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
 import com.goalpanzi.mission_mate.core.navigation.di.AuthNavigation
 import com.goalpanzi.mission_mate.core.network.TokenExpirationHandler
 import kotlinx.coroutines.flow.collect
@@ -18,7 +19,7 @@ class AuthTokenExpirationHandler @Inject constructor(
 
     override suspend fun handleRefreshTokenExpiration() {
         clearCachedData()
-        authNavigationEventHandler.triggerRouteToNavigate("RouteModel.Login")
+        authNavigationEventHandler.triggerRouteToNavigate(RouteModel.Login)
     }
 
     private suspend fun clearCachedData(){

--- a/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/AuthNavigationEventHandler.kt
+++ b/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/AuthNavigationEventHandler.kt
@@ -7,10 +7,10 @@ import javax.inject.Inject
 
 class AuthNavigationEventHandler @Inject constructor() : NavigationEventHandler {
 
-    private val _routeToNavigate = MutableSharedFlow<String>()
-    override val routeToNavigate: SharedFlow<String> = _routeToNavigate.asSharedFlow()
+    private val _routeToNavigate = MutableSharedFlow<RouteModel>()
+    override val routeToNavigate: SharedFlow<RouteModel> = _routeToNavigate.asSharedFlow()
 
-    override suspend fun triggerRouteToNavigate(route: String) {
+    override suspend fun triggerRouteToNavigate(route: RouteModel) {
         _routeToNavigate.emit(route)
     }
 }

--- a/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/NavigationEventHandler.kt
+++ b/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/NavigationEventHandler.kt
@@ -3,7 +3,7 @@ package com.goalpanzi.mission_mate.core.navigation
 import kotlinx.coroutines.flow.SharedFlow
 
 interface NavigationEventHandler {
-    val routeToNavigate : SharedFlow<String>
+    val routeToNavigate : SharedFlow<RouteModel>
 
-    suspend fun triggerRouteToNavigate(route : String)
+    suspend fun triggerRouteToNavigate(route : RouteModel)
 }

--- a/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
@@ -7,7 +7,7 @@ sealed interface RouteModel {
     data object Login : RouteModel
 
     @Serializable
-    data object Onboarding : RouteModel
+    data class Onboarding(val isAfterProfileCreate: Boolean = false) : RouteModel
 
     @Serializable
     sealed interface Profile: RouteModel {

--- a/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
@@ -16,46 +16,43 @@ sealed interface RouteModel {
     }
 
     @Serializable
-    sealed interface Mission: RouteModel {
-        @Serializable
-        data class Board(val missionId : Long) : Mission
-
-        @Serializable
-        data class Detail(val missionId : Long) : Mission
-
-        @Serializable
-        data class Finish(val missionId : Long) : Mission
-
-        @Serializable
-        data class UserStory(
-            val userCharacter : String,
-            val nickname : String,
-            val verifiedAt : String,
-            val imageUrl : String
-        ) : Mission
-
-        @Serializable
-        data class VerificationPreview(
-            val missionId : Long,
-            val imageUrl : String
-        ) : Mission
-    }
-
-    @Serializable
     sealed interface MainTabRoute : RouteModel {
         @Serializable
-        sealed interface OnboardingRouteModel : MainTabRoute {
+        sealed interface MissionRouteModel : MainTabRoute {
             @Serializable
-            data class Onboarding(val isAfterProfileCreate: Boolean = false) : OnboardingRouteModel
+            data class Onboarding(val isAfterProfileCreate: Boolean = false) : MissionRouteModel
 
             @Serializable
-            data object BoardSetup : OnboardingRouteModel
+            data object BoardSetup : MissionRouteModel
 
             @Serializable
-            data object BoardSetupSuccess : OnboardingRouteModel
+            data object BoardSetupSuccess : MissionRouteModel
 
             @Serializable
-            data object InvitationCode : OnboardingRouteModel
+            data object InvitationCode : MissionRouteModel
+
+            @Serializable
+            data class Board(val missionId : Long) : MissionRouteModel
+
+            @Serializable
+            data class Detail(val missionId : Long) : MissionRouteModel
+
+            @Serializable
+            data class Finish(val missionId : Long) : MissionRouteModel
+
+            @Serializable
+            data class UserStory(
+                val userCharacter : String,
+                val nickname : String,
+                val verifiedAt : String,
+                val imageUrl : String
+            ) : MissionRouteModel
+
+            @Serializable
+            data class VerificationPreview(
+                val missionId : Long,
+                val imageUrl : String
+            ) : MissionRouteModel
         }
 
         @Serializable

--- a/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
@@ -16,30 +16,15 @@ sealed interface RouteModel {
     }
 
     @Serializable
-    sealed interface OnboardingRouteModel {
+    sealed interface Mission: RouteModel {
         @Serializable
-        data class Onboarding(val isAfterProfileCreate: Boolean = false) : RouteModel
+        data class Board(val missionId : Long) : Mission
 
         @Serializable
-        data object BoardSetup : OnboardingRouteModel
+        data class Detail(val missionId : Long) : Mission
 
         @Serializable
-        data object BoardSetupSuccess : OnboardingRouteModel
-
-        @Serializable
-        data object InvitationCode : OnboardingRouteModel
-    }
-
-    @Serializable
-    sealed interface BoardRouteModel {
-        @Serializable
-        data class Board(val missionId : Long) : BoardRouteModel
-
-        @Serializable
-        data class BoardDetail(val missionId : Long) : BoardRouteModel
-
-        @Serializable
-        data class BoardFinish(val missionId : Long) : BoardRouteModel
+        data class Finish(val missionId : Long) : Mission
 
         @Serializable
         data class UserStory(
@@ -47,26 +32,46 @@ sealed interface RouteModel {
             val nickname : String,
             val verifiedAt : String,
             val imageUrl : String
-        ) : BoardRouteModel
+        ) : Mission
 
         @Serializable
         data class VerificationPreview(
             val missionId : Long,
             val imageUrl : String
-        ) : BoardRouteModel
+        ) : Mission
     }
 
     @Serializable
-    sealed interface SettingRouteModel {
+    sealed interface MainTabRoute : RouteModel {
+        @Serializable
+        sealed interface OnboardingRouteModel : MainTabRoute {
+            @Serializable
+            data class Onboarding(val isAfterProfileCreate: Boolean = false) : OnboardingRouteModel
+
+            @Serializable
+            data object BoardSetup : OnboardingRouteModel
+
+            @Serializable
+            data object BoardSetupSuccess : OnboardingRouteModel
+
+            @Serializable
+            data object InvitationCode : OnboardingRouteModel
+        }
 
         @Serializable
-        data object Setting : SettingRouteModel
+        sealed interface HistoryRouteModel : MainTabRoute
 
         @Serializable
-        data object ServicePolicy : SettingRouteModel
+        sealed interface SettingRouteModel : MainTabRoute {
+            @Serializable
+            data object Setting : SettingRouteModel
 
-        @Serializable
-        data object PrivacyPolicy : SettingRouteModel
+            @Serializable
+            data object ServicePolicy : SettingRouteModel
+
+            @Serializable
+            data object PrivacyPolicy : SettingRouteModel
+        }
     }
 }
 

--- a/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
@@ -18,9 +18,6 @@ sealed interface RouteModel {
     }
     @Serializable
     data object Setting : RouteModel
-
-    @Serializable
-    data class Board(val missionId : Long) : RouteModel
 }
 
 sealed interface BoardRouteModel {

--- a/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
@@ -23,6 +23,31 @@ sealed interface RouteModel {
     data class Board(val missionId : Long) : RouteModel
 }
 
+sealed interface BoardRouteModel {
+    @Serializable
+    data class Board(val missionId : Long) : BoardRouteModel
+
+    @Serializable
+    data class BoardDetail(val missionId : Long) : BoardRouteModel
+
+    @Serializable
+    data class BoardFinish(val missionId : Long) : BoardRouteModel
+
+    @Serializable
+    data class UserStory(
+        val userCharacter : String,
+        val nickname : String,
+        val verifiedAt : String,
+        val imageUrl : String
+    ) : BoardRouteModel
+
+    @Serializable
+    data class VerificationPreview(
+        val missionId : Long,
+        val imageUrl : String
+    ) : BoardRouteModel
+}
+
 sealed interface OnboardingRouteModel {
     @Serializable
     data object BoardSetup : OnboardingRouteModel

--- a/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/RouteModel.kt
@@ -2,12 +2,10 @@ package com.goalpanzi.mission_mate.core.navigation
 
 import kotlinx.serialization.Serializable
 
+
 sealed interface RouteModel {
     @Serializable
     data object Login : RouteModel
-
-    @Serializable
-    data class Onboarding(val isAfterProfileCreate: Boolean = false) : RouteModel
 
     @Serializable
     sealed interface Profile: RouteModel {
@@ -16,51 +14,62 @@ sealed interface RouteModel {
         @Serializable
         data object Setting : Profile
     }
+
     @Serializable
-    data object Setting : RouteModel
+    sealed interface OnboardingRouteModel {
+        @Serializable
+        data class Onboarding(val isAfterProfileCreate: Boolean = false) : RouteModel
+
+        @Serializable
+        data object BoardSetup : OnboardingRouteModel
+
+        @Serializable
+        data object BoardSetupSuccess : OnboardingRouteModel
+
+        @Serializable
+        data object InvitationCode : OnboardingRouteModel
+    }
+
+    @Serializable
+    sealed interface BoardRouteModel {
+        @Serializable
+        data class Board(val missionId : Long) : BoardRouteModel
+
+        @Serializable
+        data class BoardDetail(val missionId : Long) : BoardRouteModel
+
+        @Serializable
+        data class BoardFinish(val missionId : Long) : BoardRouteModel
+
+        @Serializable
+        data class UserStory(
+            val userCharacter : String,
+            val nickname : String,
+            val verifiedAt : String,
+            val imageUrl : String
+        ) : BoardRouteModel
+
+        @Serializable
+        data class VerificationPreview(
+            val missionId : Long,
+            val imageUrl : String
+        ) : BoardRouteModel
+    }
+
+    @Serializable
+    sealed interface SettingRouteModel {
+
+        @Serializable
+        data object Setting : SettingRouteModel
+
+        @Serializable
+        data object ServicePolicy : SettingRouteModel
+
+        @Serializable
+        data object PrivacyPolicy : SettingRouteModel
+    }
 }
 
-sealed interface BoardRouteModel {
-    @Serializable
-    data class Board(val missionId : Long) : BoardRouteModel
-
-    @Serializable
-    data class BoardDetail(val missionId : Long) : BoardRouteModel
-
-    @Serializable
-    data class BoardFinish(val missionId : Long) : BoardRouteModel
-
-    @Serializable
-    data class UserStory(
-        val userCharacter : String,
-        val nickname : String,
-        val verifiedAt : String,
-        val imageUrl : String
-    ) : BoardRouteModel
-
-    @Serializable
-    data class VerificationPreview(
-        val missionId : Long,
-        val imageUrl : String
-    ) : BoardRouteModel
-}
-
-sealed interface OnboardingRouteModel {
-    @Serializable
-    data object BoardSetup : OnboardingRouteModel
-
-    @Serializable
-    data object BoardSetupSuccess : OnboardingRouteModel
-
-    @Serializable
-    data object InvitationCode : OnboardingRouteModel
-}
-
-sealed interface SettingRouteModel {
-
-    @Serializable
-    data object ServicePolicy : SettingRouteModel
-
-    @Serializable
-    data object PrivacyPolicy : SettingRouteModel
+fun RouteModel.fullPathName(): String? {
+    return this::class.qualifiedName
 }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
@@ -6,7 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.BoardRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.Mission
 import com.goalpanzi.mission_mate.feature.board.model.CharacterUiModel
 import com.goalpanzi.mission_mate.feature.board.model.UserStory
 import com.goalpanzi.mission_mate.feature.board.screen.BoardFinishRoute
@@ -25,7 +25,7 @@ fun NavController.navigateToBoard(
         }
     }
 ) {
-    this.navigate(BoardRouteModel.Board(missionId), navOptions = navOptions)
+    this.navigate(Mission.Board(missionId), navOptions = navOptions)
 }
 
 fun NavGraphBuilder.boardNavGraph(
@@ -36,7 +36,7 @@ fun NavGraphBuilder.boardNavGraph(
     onClickSetting: () -> Unit,
     onNavigateToPreview: (Long, Uri) -> Unit
 ) {
-    composable<BoardRouteModel.Board> { navBackStackEntry ->
+    composable<Mission.Board> { navBackStackEntry ->
         BoardRoute(
             onNavigateOnboarding = onNavigateOnboarding,
             onNavigateDetail = onNavigateDetail,
@@ -51,14 +51,14 @@ fun NavGraphBuilder.boardNavGraph(
 fun NavController.navigateToBoardDetail(
     missionId: Long
 ) {
-    this.navigate(BoardRouteModel.BoardDetail(missionId))
+    this.navigate(Mission.Detail(missionId))
 }
 
 fun NavGraphBuilder.boardDetailNavGraph(
     onNavigateOnboarding: () -> Unit,
     onBackClick: () -> Unit
 ) {
-    composable<BoardRouteModel.BoardDetail> {
+    composable<Mission.Detail> {
         BoardMissionDetailRoute(
             onNavigateOnboarding = onNavigateOnboarding,
             onBackClick = onBackClick
@@ -69,14 +69,14 @@ fun NavGraphBuilder.boardDetailNavGraph(
 fun NavController.navigateToBoardFinish(
     missionId: Long
 ) {
-    this.navigate(BoardRouteModel.BoardFinish(missionId))
+    this.navigate(Mission.Finish(missionId))
 }
 
 fun NavGraphBuilder.boardFinishNavGraph(
     onClickSetting: () -> Unit,
     onClickOk: () -> Unit,
 ) {
-    composable<BoardRouteModel.BoardFinish> {
+    composable<Mission.Finish> {
         BoardFinishRoute(
             onSettingClick = onClickSetting,
             onOkClick = onClickOk
@@ -90,7 +90,7 @@ fun NavController.navigateToUserStory(
     val encodedUrl = URLEncoder.encode(imageUrl, StandardCharsets.UTF_8.toString())
     this@navigateToUserStory
         .navigate(
-            BoardRouteModel.UserStory(
+            Mission.UserStory(
                 userCharacter = characterUiModelType.name.uppercase(),
                 nickname = nickname,
                 verifiedAt = verifiedAt,
@@ -102,8 +102,8 @@ fun NavController.navigateToUserStory(
 fun NavGraphBuilder.userStoryNavGraph(
     onClickClose: () -> Unit
 ) {
-    composable<BoardRouteModel.UserStory> { backStackEntry ->
-        backStackEntry.toRoute<BoardRouteModel.UserStory>().run {
+    composable<Mission.UserStory> { backStackEntry ->
+        backStackEntry.toRoute<Mission.UserStory>().run {
             val characterUiModel = userCharacter.let { CharacterUiModel.valueOf(it) }
             UserStoryScreen(
                 characterUiModel = characterUiModel,
@@ -121,14 +121,14 @@ fun NavController.navigateToVerificationPreview(
     imageUrl: Uri
 ) {
     val encodedUrl = URLEncoder.encode(imageUrl.toString(), StandardCharsets.UTF_8.toString())
-    this.navigate(BoardRouteModel.VerificationPreview(missionId,encodedUrl))
+    this.navigate(Mission.VerificationPreview(missionId,encodedUrl))
 }
 
 fun NavGraphBuilder.verificationPreviewNavGraph(
     onClickClose: () -> Unit,
     onUploadSuccess: () -> Unit
 ) {
-    composable<BoardRouteModel.VerificationPreview> {
+    composable<Mission.VerificationPreview> {
         VerificationPreviewRoute(
             onClickClose = onClickClose,
             onUploadSuccess = { onUploadSuccess() }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
@@ -6,7 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.Mission
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.MissionRouteModel
 import com.goalpanzi.mission_mate.feature.board.model.CharacterUiModel
 import com.goalpanzi.mission_mate.feature.board.model.UserStory
 import com.goalpanzi.mission_mate.feature.board.screen.BoardFinishRoute
@@ -25,7 +25,7 @@ fun NavController.navigateToBoard(
         }
     }
 ) {
-    this.navigate(Mission.Board(missionId), navOptions = navOptions)
+    this.navigate(MissionRouteModel.Board(missionId), navOptions = navOptions)
 }
 
 fun NavGraphBuilder.boardNavGraph(
@@ -36,7 +36,7 @@ fun NavGraphBuilder.boardNavGraph(
     onClickSetting: () -> Unit,
     onNavigateToPreview: (Long, Uri) -> Unit
 ) {
-    composable<Mission.Board> { navBackStackEntry ->
+    composable<MissionRouteModel.Board> { navBackStackEntry ->
         BoardRoute(
             onNavigateOnboarding = onNavigateOnboarding,
             onNavigateDetail = onNavigateDetail,
@@ -51,14 +51,14 @@ fun NavGraphBuilder.boardNavGraph(
 fun NavController.navigateToBoardDetail(
     missionId: Long
 ) {
-    this.navigate(Mission.Detail(missionId))
+    this.navigate(MissionRouteModel.Detail(missionId))
 }
 
 fun NavGraphBuilder.boardDetailNavGraph(
     onNavigateOnboarding: () -> Unit,
     onBackClick: () -> Unit
 ) {
-    composable<Mission.Detail> {
+    composable<MissionRouteModel.Detail> {
         BoardMissionDetailRoute(
             onNavigateOnboarding = onNavigateOnboarding,
             onBackClick = onBackClick
@@ -69,14 +69,14 @@ fun NavGraphBuilder.boardDetailNavGraph(
 fun NavController.navigateToBoardFinish(
     missionId: Long
 ) {
-    this.navigate(Mission.Finish(missionId))
+    this.navigate(MissionRouteModel.Finish(missionId))
 }
 
 fun NavGraphBuilder.boardFinishNavGraph(
     onClickSetting: () -> Unit,
     onClickOk: () -> Unit,
 ) {
-    composable<Mission.Finish> {
+    composable<MissionRouteModel.Finish> {
         BoardFinishRoute(
             onSettingClick = onClickSetting,
             onOkClick = onClickOk
@@ -90,7 +90,7 @@ fun NavController.navigateToUserStory(
     val encodedUrl = URLEncoder.encode(imageUrl, StandardCharsets.UTF_8.toString())
     this@navigateToUserStory
         .navigate(
-            Mission.UserStory(
+            MissionRouteModel.UserStory(
                 userCharacter = characterUiModelType.name.uppercase(),
                 nickname = nickname,
                 verifiedAt = verifiedAt,
@@ -102,8 +102,8 @@ fun NavController.navigateToUserStory(
 fun NavGraphBuilder.userStoryNavGraph(
     onClickClose: () -> Unit
 ) {
-    composable<Mission.UserStory> { backStackEntry ->
-        backStackEntry.toRoute<Mission.UserStory>().run {
+    composable<MissionRouteModel.UserStory> { backStackEntry ->
+        backStackEntry.toRoute<MissionRouteModel.UserStory>().run {
             val characterUiModel = userCharacter.let { CharacterUiModel.valueOf(it) }
             UserStoryScreen(
                 characterUiModel = characterUiModel,
@@ -121,14 +121,14 @@ fun NavController.navigateToVerificationPreview(
     imageUrl: Uri
 ) {
     val encodedUrl = URLEncoder.encode(imageUrl.toString(), StandardCharsets.UTF_8.toString())
-    this.navigate(Mission.VerificationPreview(missionId,encodedUrl))
+    this.navigate(MissionRouteModel.VerificationPreview(missionId,encodedUrl))
 }
 
 fun NavGraphBuilder.verificationPreviewNavGraph(
     onClickClose: () -> Unit,
     onUploadSuccess: () -> Unit
 ) {
-    composable<Mission.VerificationPreview> {
+    composable<MissionRouteModel.VerificationPreview> {
         VerificationPreviewRoute(
             onClickClose = onClickClose,
             onUploadSuccess = { onUploadSuccess() }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
@@ -6,7 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.goalpanzi.mission_mate.core.navigation.BoardRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.BoardRouteModel
 import com.goalpanzi.mission_mate.feature.board.model.CharacterUiModel
 import com.goalpanzi.mission_mate.feature.board.model.UserStory
 import com.goalpanzi.mission_mate.feature.board.screen.BoardFinishRoute

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardDetailViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardDetailViewModel.kt
@@ -8,7 +8,7 @@ import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.DeleteMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
-import com.goalpanzi.mission_mate.core.navigation.BoardRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.BoardRouteModel
 import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardDetailViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardDetailViewModel.kt
@@ -8,7 +8,7 @@ import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.DeleteMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.BoardRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.Mission
 import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,7 +34,7 @@ class BoardDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val missionId: Long = savedStateHandle.toRoute<BoardRouteModel.BoardDetail>().missionId
+    private val missionId: Long = savedStateHandle.toRoute<Mission.Detail>().missionId
 
     private val memberId : StateFlow<Long?> = getCachedMemberIdUseCase().stateIn(
         viewModelScope,

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardDetailViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardDetailViewModel.kt
@@ -3,10 +3,12 @@ package com.goalpanzi.mission_mate.feature.board.screen
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.DeleteMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
+import com.goalpanzi.mission_mate.core.navigation.BoardRouteModel
 import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,7 +34,7 @@ class BoardDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val missionId: Long = savedStateHandle.get<Long>("missionId")!!
+    private val missionId: Long = savedStateHandle.toRoute<BoardRouteModel.BoardDetail>().missionId
 
     private val memberId : StateFlow<Long?> = getCachedMemberIdUseCase().stateIn(
         viewModelScope,

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardDetailViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardDetailViewModel.kt
@@ -8,7 +8,7 @@ import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.DeleteMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.Mission
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.MissionRouteModel
 import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,7 +34,7 @@ class BoardDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val missionId: Long = savedStateHandle.toRoute<Mission.Detail>().missionId
+    private val missionId: Long = savedStateHandle.toRoute<MissionRouteModel.Detail>().missionId
 
     private val memberId : StateFlow<Long?> = getCachedMemberIdUseCase().stateIn(
         viewModelScope,

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishViewModel.kt
@@ -11,7 +11,7 @@ import com.goalpanzi.mission_mate.core.domain.mission.usecase.CompleteMissionUse
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionRankUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.SetMissionJoinedUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
-import com.goalpanzi.mission_mate.core.navigation.BoardRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.BoardRouteModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishViewModel.kt
@@ -10,7 +10,7 @@ import com.goalpanzi.mission_mate.core.domain.mission.usecase.CompleteMissionUse
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionRankUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.SetMissionJoinedUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.Mission
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.MissionRouteModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,7 +33,7 @@ class BoardFinishViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val missionId: Long = savedStateHandle.toRoute<Mission.Finish>().missionId
+    private val missionId: Long = savedStateHandle.toRoute<MissionRouteModel.Finish>().missionId
 
     private val _rank : MutableStateFlow<Int?> = MutableStateFlow(null)
     val rank : StateFlow<Int?> = _rank.asStateFlow()

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishViewModel.kt
@@ -3,6 +3,7 @@ package com.goalpanzi.mission_mate.feature.board.screen
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.common.convert
 import com.goalpanzi.mission_mate.core.domain.common.model.user.UserProfile
@@ -10,6 +11,7 @@ import com.goalpanzi.mission_mate.core.domain.mission.usecase.CompleteMissionUse
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionRankUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.SetMissionJoinedUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
+import com.goalpanzi.mission_mate.core.navigation.BoardRouteModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,7 +34,7 @@ class BoardFinishViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val missionId: Long = savedStateHandle.get<Long>("missionId")!!
+    private val missionId: Long = savedStateHandle.toRoute<BoardRouteModel.BoardFinish>().missionId
 
     private val _rank : MutableStateFlow<Int?> = MutableStateFlow(null)
     val rank : StateFlow<Int?> = _rank.asStateFlow()

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardFinishViewModel.kt
@@ -5,13 +5,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.goalpanzi.mission_mate.core.domain.common.DomainResult
-import com.goalpanzi.mission_mate.core.domain.common.convert
 import com.goalpanzi.mission_mate.core.domain.common.model.user.UserProfile
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.CompleteMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMissionRankUseCase
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.SetMissionJoinedUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.BoardRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.Mission
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,7 +33,7 @@ class BoardFinishViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val missionId: Long = savedStateHandle.toRoute<BoardRouteModel.BoardFinish>().missionId
+    private val missionId: Long = savedStateHandle.toRoute<Mission.Finish>().missionId
 
     private val _rank : MutableStateFlow<Int?> = MutableStateFlow(null)
     val rank : StateFlow<Int?> = _rank.asStateFlow()

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
@@ -60,12 +60,11 @@ import kotlinx.coroutines.launch
 @Composable
 fun BoardRoute(
     onNavigateOnboarding: () -> Unit,
-    onNavigateDetail: () -> Unit,
+    onNavigateDetail: (Long) -> Unit,
     onNavigateFinish : (Long) -> Unit,
     onClickSetting: () -> Unit,
     onClickStory: (UserStory) -> Unit,
     onPreviewImage: (Long, Uri) -> Unit,
-    isUploadSuccess: Boolean,
     modifier: Modifier = Modifier,
     viewModel: BoardViewModel = hiltViewModel()
 ) {
@@ -210,7 +209,7 @@ fun BoardRoute(
         onClickSetting = onClickSetting,
         onClickFlag = {
             viewModel.setViewedTooltip()
-            onNavigateDetail()
+            onNavigateDetail(viewModel.missionId)
         },
         onClickAddUser = {
             viewModel.setViewedTooltip()

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -18,7 +18,7 @@ import com.goalpanzi.mission_mate.core.domain.setting.usecase.GetViewedTooltipUs
 import com.goalpanzi.mission_mate.core.domain.setting.usecase.SetViewedTooltipUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
-import com.goalpanzi.mission_mate.core.navigation.BoardRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.BoardRouteModel
 import com.goalpanzi.mission_mate.feature.board.model.BoardPiece
 import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.MissionState

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -18,7 +18,7 @@ import com.goalpanzi.mission_mate.core.domain.setting.usecase.GetViewedTooltipUs
 import com.goalpanzi.mission_mate.core.domain.setting.usecase.SetViewedTooltipUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.BoardRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.Mission
 import com.goalpanzi.mission_mate.feature.board.model.BoardPiece
 import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.MissionState
@@ -68,7 +68,7 @@ class BoardViewModel @Inject constructor(
     private val viewVerificationUseCase: ViewVerificationUseCase
 ) : ViewModel() {
 
-    val missionId: Long = savedStateHandle.toRoute<BoardRouteModel.Board>().missionId
+    val missionId: Long = savedStateHandle.toRoute<Mission.Board>().missionId
 
     val viewedToolTip: StateFlow<Boolean> = getViewedTooltipUseCase().stateIn(
         viewModelScope,

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -3,6 +3,7 @@ package com.goalpanzi.mission_mate.feature.board.screen
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.common.model.mission.MissionStatus.Companion.statusString
 import com.goalpanzi.mission_mate.core.domain.mission.model.BoardReward
@@ -17,6 +18,7 @@ import com.goalpanzi.mission_mate.core.domain.setting.usecase.GetViewedTooltipUs
 import com.goalpanzi.mission_mate.core.domain.setting.usecase.SetViewedTooltipUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
+import com.goalpanzi.mission_mate.core.navigation.BoardRouteModel
 import com.goalpanzi.mission_mate.feature.board.model.BoardPiece
 import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.MissionState
@@ -66,7 +68,7 @@ class BoardViewModel @Inject constructor(
     private val viewVerificationUseCase: ViewVerificationUseCase
 ) : ViewModel() {
 
-    val missionId: Long = savedStateHandle.get<Long>("missionId")!!
+    val missionId: Long = savedStateHandle.toRoute<BoardRouteModel.Board>().missionId
 
     val viewedToolTip: StateFlow<Boolean> = getViewedTooltipUseCase().stateIn(
         viewModelScope,

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardViewModel.kt
@@ -18,7 +18,7 @@ import com.goalpanzi.mission_mate.core.domain.setting.usecase.GetViewedTooltipUs
 import com.goalpanzi.mission_mate.core.domain.setting.usecase.SetViewedTooltipUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetCachedMemberIdUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.Mission
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.MissionRouteModel
 import com.goalpanzi.mission_mate.feature.board.model.BoardPiece
 import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.MissionState
@@ -68,7 +68,7 @@ class BoardViewModel @Inject constructor(
     private val viewVerificationUseCase: ViewVerificationUseCase
 ) : ViewModel() {
 
-    val missionId: Long = savedStateHandle.toRoute<Mission.Board>().missionId
+    val missionId: Long = savedStateHandle.toRoute<MissionRouteModel.Board>().missionId
 
     val viewedToolTip: StateFlow<Boolean> = getViewedTooltipUseCase().stateIn(
         viewModelScope,

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/VerificationPreviewViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/VerificationPreviewViewModel.kt
@@ -8,7 +8,7 @@ import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.common.model.user.UserProfile
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.VerifyMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.BoardRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.Mission
 import com.goalpanzi.mission_mate.feature.board.model.CharacterUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -33,8 +33,8 @@ class VerificationPreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val missionId = savedStateHandle.toRoute<BoardRouteModel.VerificationPreview>().missionId
-    private val imageUrl = savedStateHandle.toRoute<BoardRouteModel.VerificationPreview>().imageUrl
+    private val missionId = savedStateHandle.toRoute<Mission.VerificationPreview>().missionId
+    private val imageUrl = savedStateHandle.toRoute<Mission.VerificationPreview>().imageUrl
 
     private val _eventFlow = MutableSharedFlow<UploadEvent>()
     val eventFlow = _eventFlow.asSharedFlow()

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/VerificationPreviewViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/VerificationPreviewViewModel.kt
@@ -8,7 +8,7 @@ import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.common.model.user.UserProfile
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.VerifyMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.Mission
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.MissionRouteModel
 import com.goalpanzi.mission_mate.feature.board.model.CharacterUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -33,8 +33,8 @@ class VerificationPreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
-    private val missionId = savedStateHandle.toRoute<Mission.VerificationPreview>().missionId
-    private val imageUrl = savedStateHandle.toRoute<Mission.VerificationPreview>().imageUrl
+    private val missionId = savedStateHandle.toRoute<MissionRouteModel.VerificationPreview>().missionId
+    private val imageUrl = savedStateHandle.toRoute<MissionRouteModel.VerificationPreview>().imageUrl
 
     private val _eventFlow = MutableSharedFlow<UploadEvent>()
     val eventFlow = _eventFlow.asSharedFlow()

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/VerificationPreviewViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/VerificationPreviewViewModel.kt
@@ -8,7 +8,7 @@ import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.common.model.user.UserProfile
 import com.goalpanzi.mission_mate.core.domain.mission.usecase.VerifyMissionUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
-import com.goalpanzi.mission_mate.core.navigation.BoardRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.BoardRouteModel
 import com.goalpanzi.mission_mate.feature.board.model.CharacterUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginNavigation.kt
+++ b/feature/login/src/main/java/com/goalpanzi/mission_mate/feature/login/LoginNavigation.kt
@@ -3,9 +3,10 @@ package com.goalpanzi.mission_mate.feature.login
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
 
 fun NavController.navigateToLogin() {
-    this.navigate("RouteModel.Login") {
+    this.navigate(RouteModel.Login) {
         popUpTo(this@navigateToLogin.graph.id){
             inclusive = true
         }
@@ -15,7 +16,7 @@ fun NavController.navigateToLogin() {
 fun NavGraphBuilder.loginNavGraph(
     onLoginSuccess: (isProfileSet: Boolean) -> Unit
 ) {
-    composable("RouteModel.Login") {
+    composable<RouteModel.Login> {
         LoginRoute(
             onLoginSuccess = onLoginSuccess
         )

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : ComponentActivity() {
                         if (user == null) {
                             RouteModel.Profile.Create
                         } else {
-                            RouteModel.Onboarding()
+                            RouteModel.OnboardingRouteModel.Onboarding()
                         }
                     }
                 )

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : ComponentActivity() {
                         if (user == null) {
                             RouteModel.Profile.Create
                         } else {
-                            RouteModel.OnboardingRouteModel.Onboarding()
+                            RouteModel.MainTabRoute.OnboardingRouteModel.Onboarding()
                         }
                     }
                 )

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : ComponentActivity() {
                         if (user == null) {
                             RouteModel.Profile.Create
                         } else {
-                            RouteModel.MainTabRoute.OnboardingRouteModel.Onboarding()
+                            RouteModel.MainTabRoute.MissionRouteModel.Onboarding()
                         }
                     }
                 )

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.goalpanzi.mission_mate.core.designsystem.theme.MissionmateTheme
 import com.goalpanzi.mission_mate.core.domain.auth.usecase.LoginUseCase
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
 import com.goalpanzi.mission_mate.feature.main.component.MainNavigator
 import com.goalpanzi.mission_mate.feature.main.component.rememberMainNavigator
 import dagger.hilt.android.AndroidEntryPoint
@@ -33,12 +34,12 @@ class MainActivity : ComponentActivity() {
                 MainScreen(
                     navigator = navigator,
                     startDestination = if (isNewUser) {
-                        "RouteModel.Login"
+                        RouteModel.Login
                     } else {
                         if (user == null) {
-                            "RouteModel.Profile.Create"
+                            RouteModel.Profile.Create
                         } else {
-                            "RouteModel.Onboarding?isAfterProfileCreate={isAfterProfileCreate}"
+                            RouteModel.Onboarding()
                         }
                     }
                 )

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainScreen.kt
@@ -9,6 +9,7 @@ import com.goalpanzi.mission_mate.core.navigation.RouteModel
 import com.goalpanzi.mission_mate.feature.main.component.MainNavHost
 import com.goalpanzi.mission_mate.feature.main.component.MainNavigator
 import com.goalpanzi.mission_mate.feature.main.component.rememberMainNavigator
+import com.goalpanzi.mission_mate.feature.main.ext.compareTo
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
@@ -22,10 +23,10 @@ internal fun MainScreen(
 ) {
     LaunchedEffect(Unit) {
         viewModel.navigationEvent.debounce(200).collectLatest { route ->
-            if(navigator.navController.currentDestination?.route != route){
-                if(route == "RouteModel.Login"){
+            if(navigator.navController.currentDestination?.compareTo(route) == false) {
+                if (route == RouteModel.Login) {
                     navigator.navigateToLogin()
-                }else {
+                } else {
                     navigator.navController.navigate(route)
                 }
             }

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
 import com.goalpanzi.mission_mate.feature.main.component.MainNavHost
 import com.goalpanzi.mission_mate.feature.main.component.MainNavigator
 import com.goalpanzi.mission_mate.feature.main.component.rememberMainNavigator
@@ -15,7 +16,7 @@ import kotlinx.coroutines.flow.debounce
 @OptIn(FlowPreview::class)
 @Composable
 internal fun MainScreen(
-    startDestination: String,
+    startDestination: RouteModel,
     navigator: MainNavigator = rememberMainNavigator(),
     viewModel: MainViewModel = hiltViewModel()
 ) {
@@ -40,7 +41,7 @@ internal fun MainScreen(
 @Composable
 private fun MainScreenContent(
     navigator: MainNavigator,
-    startDestination: String,
+    startDestination: RouteModel,
     modifier: Modifier = Modifier
 ) {
     Scaffold(

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/MainViewModel.kt
@@ -1,9 +1,13 @@
 package com.goalpanzi.mission_mate.feature.main
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.goalpanzi.mission_mate.core.navigation.NavigationEventHandler
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
 import com.goalpanzi.mission_mate.core.navigation.di.AuthNavigation
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavHost.kt
@@ -22,6 +22,7 @@ import com.goalpanzi.mission_mate.feature.board.boardNavGraph
 import com.goalpanzi.mission_mate.feature.board.userStoryNavGraph
 import com.goalpanzi.mission_mate.feature.board.verificationPreviewNavGraph
 import com.goalpanzi.mission_mate.feature.login.loginNavGraph
+import com.goalpanzi.mission_mate.feature.main.ext.isDarkStatusBarScreen
 import com.goalpanzi.mission_mate.feature.onboarding.boardSetupNavGraph
 import com.goalpanzi.mission_mate.feature.onboarding.boardSetupSuccessNavGraph
 import com.goalpanzi.mission_mate.feature.onboarding.invitationCodeNavGraph
@@ -40,10 +41,10 @@ internal fun MainNavHost(
 ) {
     val context = LocalContext.current
     val currentBackStackEntry by navigator.navController.currentBackStackEntryAsState()
-    val currentRoute = currentBackStackEntry?.destination?.route
+    val currentRoute = currentBackStackEntry?.destination
 
     LaunchedEffect(currentRoute) {
-        if (navigator.isDarkStatusBarScreen(currentRoute)) {
+        if (currentRoute.isDarkStatusBarScreen()) {
             setStatusBar(context, false)
         } else if(!isLightStatusBars(context as Activity)){
             setStatusBar(context, true)
@@ -160,3 +161,4 @@ internal fun MainNavHost(
         }
     }
 }
+

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavHost.kt
@@ -155,9 +155,6 @@ internal fun MainNavHost(
                 },
                 onUploadSuccess = {
                     navigator.popBackStack()
-                    navigator.navController.currentBackStackEntry
-                        ?.savedStateHandle
-                        ?.set(it, true)
                 }
             )
         }

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavHost.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import com.goalpanzi.mission_mate.core.designsystem.theme.ColorWhite_FFFFFFFF
 import com.goalpanzi.mission_mate.core.designsystem.util.isLightStatusBars
 import com.goalpanzi.mission_mate.core.designsystem.util.setStatusBar
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
 import com.goalpanzi.mission_mate.feature.board.boardDetailNavGraph
 import com.goalpanzi.mission_mate.feature.board.boardFinishNavGraph
 import com.goalpanzi.mission_mate.feature.board.boardNavGraph
@@ -34,7 +35,7 @@ import com.goalpanzi.mission_mate.feature.setting.navigation.settingNavGraph
 internal fun MainNavHost(
     modifier: Modifier = Modifier,
     navigator: MainNavigator,
-    startDestination: String,
+    startDestination: RouteModel,
     padding: PaddingValues
 ) {
     val context = LocalContext.current

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavigator.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavigator.kt
@@ -91,11 +91,6 @@ class MainNavigator(
     fun navigationToVerificationPreview(missionId: Long, imageUrl : Uri) {
         navController.navigateToVerificationPreview(missionId, imageUrl)
     }
-
-    fun isDarkStatusBarScreen(currentRoute: String?): Boolean {
-        return currentRoute?.contains("RouteModel.VerificationPreview") == true
-                || currentRoute?.contains("RouteModel.UserStory") == true
-    }
 }
 
 @Composable
@@ -104,3 +99,4 @@ internal fun rememberMainNavigator(
 ) : MainNavigator = remember(navController) {
     MainNavigator(navController)
 }
+

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/ext/NavDestination.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/ext/NavDestination.kt
@@ -9,8 +9,8 @@ fun NavDestination?.compareTo(routeModel: RouteModel) : Boolean {
 }
 
 private val darkStatusBarScreenRouteNames = setOf(
-    RouteModel.Mission.UserStory::class.qualifiedName,
-    RouteModel.Mission.VerificationPreview::class.qualifiedName
+    RouteModel.MainTabRoute.MissionRouteModel.UserStory::class.qualifiedName,
+    RouteModel.MainTabRoute.MissionRouteModel.VerificationPreview::class.qualifiedName
 )
 
 fun NavDestination?.isDarkStatusBarScreen() : Boolean {

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/ext/NavDestination.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/ext/NavDestination.kt
@@ -8,3 +8,15 @@ fun NavDestination?.compareTo(routeModel: RouteModel) : Boolean {
     return this?.route == routeModel.fullPathName()
 }
 
+private val darkStatusBarScreenRouteNames = setOf(
+    RouteModel.BoardRouteModel.UserStory::class.qualifiedName,
+    RouteModel.BoardRouteModel.VerificationPreview::class.qualifiedName
+)
+
+fun NavDestination?.isDarkStatusBarScreen() : Boolean {
+    if(this?.route == null) return false
+    return darkStatusBarScreenRouteNames.any { name ->
+        route?.contains(name ?: return false) == true
+    }
+}
+

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/ext/NavDestination.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/ext/NavDestination.kt
@@ -9,8 +9,8 @@ fun NavDestination?.compareTo(routeModel: RouteModel) : Boolean {
 }
 
 private val darkStatusBarScreenRouteNames = setOf(
-    RouteModel.BoardRouteModel.UserStory::class.qualifiedName,
-    RouteModel.BoardRouteModel.VerificationPreview::class.qualifiedName
+    RouteModel.Mission.UserStory::class.qualifiedName,
+    RouteModel.Mission.VerificationPreview::class.qualifiedName
 )
 
 fun NavDestination?.isDarkStatusBarScreen() : Boolean {

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/ext/NavDestination.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/ext/NavDestination.kt
@@ -1,0 +1,10 @@
+package com.goalpanzi.mission_mate.feature.main.ext
+
+import androidx.navigation.NavDestination
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
+import com.goalpanzi.mission_mate.core.navigation.fullPathName
+
+fun NavDestination?.compareTo(routeModel: RouteModel) : Boolean {
+    return this?.route == routeModel.fullPathName()
+}
+

--- a/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/OnboardingNavigation.kt
@@ -4,8 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.goalpanzi.mission_mate.core.navigation.OnboardingRouteModel
-import com.goalpanzi.mission_mate.core.navigation.RouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.OnboardingRouteModel
 import com.goalpanzi.mission_mate.feature.onboarding.screen.OnboardingRoute
 import com.goalpanzi.mission_mate.feature.onboarding.screen.boardsetup.BoardSetupRoute
 import com.goalpanzi.mission_mate.feature.onboarding.screen.boardsetup.BoardSetupSuccessScreen
@@ -19,7 +18,7 @@ fun NavController.navigateToOnboarding(
         }
     }
 ) {
-    this.navigate(RouteModel.Onboarding(isAfterProfileCreate), navOptions = navOptions)
+    this.navigate(OnboardingRouteModel.Onboarding(isAfterProfileCreate), navOptions = navOptions)
 }
 
 fun NavGraphBuilder.onboardingNavGraph(
@@ -28,7 +27,7 @@ fun NavGraphBuilder.onboardingNavGraph(
     onClickSetting: () -> Unit,
     onNavigateMissionBoard: (Long) -> Unit
 ) {
-    composable<RouteModel.Onboarding> {
+    composable<OnboardingRouteModel.Onboarding> {
         OnboardingRoute(
             onClickBoardSetup = onClickBoardSetup,
             onClickInvitationCode = onClickInvitationCode,

--- a/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/OnboardingNavigation.kt
@@ -4,7 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.OnboardingRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.MissionRouteModel
 import com.goalpanzi.mission_mate.feature.onboarding.screen.OnboardingRoute
 import com.goalpanzi.mission_mate.feature.onboarding.screen.boardsetup.BoardSetupRoute
 import com.goalpanzi.mission_mate.feature.onboarding.screen.boardsetup.BoardSetupSuccessScreen
@@ -18,7 +18,7 @@ fun NavController.navigateToOnboarding(
         }
     }
 ) {
-    this.navigate(OnboardingRouteModel.Onboarding(isAfterProfileCreate), navOptions = navOptions)
+    this.navigate(MissionRouteModel.Onboarding(isAfterProfileCreate), navOptions = navOptions)
 }
 
 fun NavGraphBuilder.onboardingNavGraph(
@@ -27,7 +27,7 @@ fun NavGraphBuilder.onboardingNavGraph(
     onClickSetting: () -> Unit,
     onNavigateMissionBoard: (Long) -> Unit
 ) {
-    composable<OnboardingRouteModel.Onboarding> {
+    composable<MissionRouteModel.Onboarding> {
         OnboardingRoute(
             onClickBoardSetup = onClickBoardSetup,
             onClickInvitationCode = onClickInvitationCode,
@@ -38,7 +38,7 @@ fun NavGraphBuilder.onboardingNavGraph(
 }
 
 fun NavController.navigateToBoardSetup() {
-    this.navigate(OnboardingRouteModel.BoardSetup)
+    this.navigate(MissionRouteModel.BoardSetup)
 }
 
 fun NavController.navigateToBoardSetupSuccess(
@@ -48,18 +48,18 @@ fun NavController.navigateToBoardSetupSuccess(
         }
     }
 ) {
-    this.navigate(OnboardingRouteModel.BoardSetupSuccess, navOptions = navOptions)
+    this.navigate(MissionRouteModel.BoardSetupSuccess, navOptions = navOptions)
 }
 
 fun NavController.navigateToInvitationCode() {
-    this.navigate(OnboardingRouteModel.InvitationCode)
+    this.navigate(MissionRouteModel.InvitationCode)
 }
 
 fun NavGraphBuilder.boardSetupNavGraph(
     onSuccess: () -> Unit,
     onBackClick: () -> Unit
 ) {
-    composable<OnboardingRouteModel.BoardSetup> {
+    composable<MissionRouteModel.BoardSetup> {
         BoardSetupRoute(
             onSuccess = onSuccess,
             onBackClick = onBackClick
@@ -70,7 +70,7 @@ fun NavGraphBuilder.boardSetupNavGraph(
 fun NavGraphBuilder.boardSetupSuccessNavGraph(
     onClickStart: () -> Unit
 ) {
-    composable<OnboardingRouteModel.BoardSetupSuccess> {
+    composable<MissionRouteModel.BoardSetupSuccess> {
         BoardSetupSuccessScreen(
             onClickStart = onClickStart
         )
@@ -81,7 +81,7 @@ fun NavGraphBuilder.invitationCodeNavGraph(
     onBackClick: () -> Unit,
     onNavigateMissionBoard: (Long) -> Unit,
 ) {
-    composable<OnboardingRouteModel.InvitationCode> {
+    composable<MissionRouteModel.InvitationCode> {
         InvitationCodeRoute(
             onBackClick = onBackClick,
             onNavigateMissionBoard = onNavigateMissionBoard

--- a/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/OnboardingNavigation.kt
@@ -3,15 +3,13 @@ package com.goalpanzi.mission_mate.feature.onboarding
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
-import androidx.navigation.NavType
 import androidx.navigation.compose.composable
-import androidx.navigation.navArgument
+import com.goalpanzi.mission_mate.core.navigation.OnboardingRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
 import com.goalpanzi.mission_mate.feature.onboarding.screen.OnboardingRoute
 import com.goalpanzi.mission_mate.feature.onboarding.screen.boardsetup.BoardSetupRoute
 import com.goalpanzi.mission_mate.feature.onboarding.screen.boardsetup.BoardSetupSuccessScreen
 import com.goalpanzi.mission_mate.feature.onboarding.screen.invitation.InvitationCodeRoute
-
-internal const val isAfterProfileCreateArg = "isAfterProfileCreate"
 
 fun NavController.navigateToOnboarding(
     isAfterProfileCreate: Boolean = false,
@@ -21,7 +19,7 @@ fun NavController.navigateToOnboarding(
         }
     }
 ) {
-    this.navigate("RouteModel.Onboarding" + "?isAfterProfileCreate=${isAfterProfileCreate}", navOptions = navOptions)
+    this.navigate(RouteModel.Onboarding(isAfterProfileCreate), navOptions = navOptions)
 }
 
 fun NavGraphBuilder.onboardingNavGraph(
@@ -30,14 +28,7 @@ fun NavGraphBuilder.onboardingNavGraph(
     onClickSetting: () -> Unit,
     onNavigateMissionBoard: (Long) -> Unit
 ) {
-    composable(
-        "RouteModel.Onboarding?${isAfterProfileCreateArg}={$isAfterProfileCreateArg}",
-        arguments = listOf(
-            navArgument(isAfterProfileCreateArg) {
-                type = NavType.BoolType
-            }
-        )
-    ) {
+    composable<RouteModel.Onboarding> {
         OnboardingRoute(
             onClickBoardSetup = onClickBoardSetup,
             onClickInvitationCode = onClickInvitationCode,
@@ -48,7 +39,7 @@ fun NavGraphBuilder.onboardingNavGraph(
 }
 
 fun NavController.navigateToBoardSetup() {
-    this.navigate("OnboardingRouteModel.BoardSetup")
+    this.navigate(OnboardingRouteModel.BoardSetup)
 }
 
 fun NavController.navigateToBoardSetupSuccess(
@@ -58,18 +49,18 @@ fun NavController.navigateToBoardSetupSuccess(
         }
     }
 ) {
-    this.navigate("OnboardingRouteModel.BoardSetupSuccess", navOptions = navOptions)
+    this.navigate(OnboardingRouteModel.BoardSetupSuccess, navOptions = navOptions)
 }
 
 fun NavController.navigateToInvitationCode() {
-    this.navigate("OnboardingRouteModel.InvitationCode")
+    this.navigate(OnboardingRouteModel.InvitationCode)
 }
 
 fun NavGraphBuilder.boardSetupNavGraph(
     onSuccess: () -> Unit,
     onBackClick: () -> Unit
 ) {
-    composable("OnboardingRouteModel.BoardSetup") {
+    composable<OnboardingRouteModel.BoardSetup> {
         BoardSetupRoute(
             onSuccess = onSuccess,
             onBackClick = onBackClick
@@ -80,7 +71,7 @@ fun NavGraphBuilder.boardSetupNavGraph(
 fun NavGraphBuilder.boardSetupSuccessNavGraph(
     onClickStart: () -> Unit
 ) {
-    composable("OnboardingRouteModel.BoardSetupSuccess") {
+    composable<OnboardingRouteModel.BoardSetupSuccess> {
         BoardSetupSuccessScreen(
             onClickStart = onClickStart
         )
@@ -91,7 +82,7 @@ fun NavGraphBuilder.invitationCodeNavGraph(
     onBackClick: () -> Unit,
     onNavigateMissionBoard: (Long) -> Unit,
 ) {
-    composable("OnboardingRouteModel.InvitationCode") {
+    composable<OnboardingRouteModel.InvitationCode> {
         InvitationCodeRoute(
             onBackClick = onBackClick,
             onNavigateMissionBoard = onNavigateMissionBoard

--- a/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/OnboardingNavigation.kt
@@ -4,7 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.OnboardingRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.OnboardingRouteModel
 import com.goalpanzi.mission_mate.feature.onboarding.screen.OnboardingRoute
 import com.goalpanzi.mission_mate.feature.onboarding.screen.boardsetup.BoardSetupRoute
 import com.goalpanzi.mission_mate.feature.onboarding.screen.boardsetup.BoardSetupSuccessScreen

--- a/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/screen/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/screen/OnboardingViewModel.kt
@@ -12,7 +12,7 @@ import com.goalpanzi.mission_mate.core.domain.onboarding.usecase.GetJoinedMissio
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetFcmTokenUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.UpdateFcmTokenUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.OnboardingRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.OnboardingRouteModel
 import com.goalpanzi.mission_mate.feature.onboarding.model.OnboardingResultEvent
 import com.goalpanzi.mission_mate.feature.onboarding.model.OnboardingUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/screen/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/screen/OnboardingViewModel.kt
@@ -3,6 +3,7 @@ package com.goalpanzi.mission_mate.feature.onboarding.screen
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.common.model.mission.MissionStatus
 import com.goalpanzi.mission_mate.core.domain.common.model.user.UserProfile
@@ -11,11 +12,10 @@ import com.goalpanzi.mission_mate.core.domain.onboarding.usecase.GetJoinedMissio
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetFcmTokenUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.UpdateFcmTokenUseCase
-import com.goalpanzi.mission_mate.feature.onboarding.isAfterProfileCreateArg
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
 import com.goalpanzi.mission_mate.feature.onboarding.model.OnboardingResultEvent
 import com.goalpanzi.mission_mate.feature.onboarding.model.OnboardingUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -47,7 +47,7 @@ class OnboardingViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            savedStateHandle.get<Boolean>(isAfterProfileCreateArg)?.let {
+            savedStateHandle.toRoute<RouteModel.Onboarding>().isAfterProfileCreate.let {
                 if (it) {
                     profileCreateSuccessEvent.emit(profileUseCase.getProfile())
                 }

--- a/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/screen/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/screen/OnboardingViewModel.kt
@@ -12,7 +12,7 @@ import com.goalpanzi.mission_mate.core.domain.onboarding.usecase.GetJoinedMissio
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetFcmTokenUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.UpdateFcmTokenUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.OnboardingRouteModel
 import com.goalpanzi.mission_mate.feature.onboarding.model.OnboardingResultEvent
 import com.goalpanzi.mission_mate.feature.onboarding.model.OnboardingUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -47,7 +47,7 @@ class OnboardingViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            savedStateHandle.toRoute<RouteModel.Onboarding>().isAfterProfileCreate.let {
+            savedStateHandle.toRoute<OnboardingRouteModel.Onboarding>().isAfterProfileCreate.let {
                 if (it) {
                     profileCreateSuccessEvent.emit(profileUseCase.getProfile())
                 }

--- a/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/screen/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/goalpanzi/mission_mate/feature/onboarding/screen/OnboardingViewModel.kt
@@ -12,7 +12,7 @@ import com.goalpanzi.mission_mate.core.domain.onboarding.usecase.GetJoinedMissio
 import com.goalpanzi.mission_mate.core.domain.user.usecase.GetFcmTokenUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.ProfileUseCase
 import com.goalpanzi.mission_mate.core.domain.user.usecase.UpdateFcmTokenUseCase
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.OnboardingRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.MissionRouteModel
 import com.goalpanzi.mission_mate.feature.onboarding.model.OnboardingResultEvent
 import com.goalpanzi.mission_mate.feature.onboarding.model.OnboardingUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -47,7 +47,7 @@ class OnboardingViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            savedStateHandle.toRoute<OnboardingRouteModel.Onboarding>().isAfterProfileCreate.let {
+            savedStateHandle.toRoute<MissionRouteModel.Onboarding>().isAfterProfileCreate.let {
                 if (it) {
                     profileCreateSuccessEvent.emit(profileUseCase.getProfile())
                 }

--- a/feature/profile/src/main/java/com/goalpanzi/mission_mate/feature/profile/ProfileNavigation.kt
+++ b/feature/profile/src/main/java/com/goalpanzi/mission_mate/feature/profile/ProfileNavigation.kt
@@ -5,24 +5,25 @@ import androidx.compose.animation.core.tween
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
 
 enum class ProfileSettingType {
     CREATE, SETTING
 }
 
 fun NavController.navigateToProfileCreate() {
-    this.navigate("RouteModel.Profile.Create")
+    this.navigate(RouteModel.Profile.Create)
 }
 
 fun NavController.navigateToProfileSetting() {
-    this.navigate("RouteModel.Profile.Setting")
+    this.navigate(RouteModel.Profile.Setting)
 }
 
 fun NavGraphBuilder.profileNavGraph(
     onSaveSuccess: () -> Unit,
     onBackClick: () -> Unit
 ) {
-    composable("RouteModel.Profile.Create",
+    composable<RouteModel.Profile.Create>(
         enterTransition = {
             slideIntoContainer(
                 towards = AnimatedContentTransitionScope.SlideDirection.Left,
@@ -35,7 +36,7 @@ fun NavGraphBuilder.profileNavGraph(
             onSaveSuccess = onSaveSuccess
         )
     }
-    composable("RouteModel.Profile.Setting") {
+    composable<RouteModel.Profile.Setting> {
         ProfileRoute(
             profileSettingType = ProfileSettingType.SETTING,
             onSaveSuccess = onBackClick,

--- a/feature/setting/src/main/java/com/goalpanzi/mission_mate/feature/setting/navigation/SettingNavigation.kt
+++ b/feature/setting/src/main/java/com/goalpanzi/mission_mate/feature/setting/navigation/SettingNavigation.kt
@@ -5,13 +5,12 @@ import androidx.compose.animation.core.tween
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.goalpanzi.mission_mate.core.navigation.RouteModel
-import com.goalpanzi.mission_mate.core.navigation.SettingRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.SettingRouteModel
 import com.goalpanzi.mission_mate.feature.setting.screen.SettingRoute
 import com.goalpanzi.mission_mate.feature.setting.screen.WebViewScreen
 
 fun NavController.navigateToSetting() {
-    this.navigate(RouteModel.Setting)
+    this.navigate(SettingRouteModel.Setting)
 }
 
 fun NavController.navigateToServicePolicy() {
@@ -29,7 +28,7 @@ fun NavGraphBuilder.settingNavGraph(
     onClickPrivacyPolicy: () -> Unit,
     onClickLogout: () -> Unit
 ) {
-    composable<RouteModel.Setting>(
+    composable<SettingRouteModel.Setting>(
         enterTransition = {
             slideIntoContainer(
                 towards = AnimatedContentTransitionScope.SlideDirection.Start,

--- a/feature/setting/src/main/java/com/goalpanzi/mission_mate/feature/setting/navigation/SettingNavigation.kt
+++ b/feature/setting/src/main/java/com/goalpanzi/mission_mate/feature/setting/navigation/SettingNavigation.kt
@@ -5,7 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.goalpanzi.mission_mate.core.navigation.RouteModel.SettingRouteModel
+import com.goalpanzi.mission_mate.core.navigation.RouteModel.MainTabRoute.SettingRouteModel
 import com.goalpanzi.mission_mate.feature.setting.screen.SettingRoute
 import com.goalpanzi.mission_mate.feature.setting.screen.WebViewScreen
 

--- a/feature/setting/src/main/java/com/goalpanzi/mission_mate/feature/setting/navigation/SettingNavigation.kt
+++ b/feature/setting/src/main/java/com/goalpanzi/mission_mate/feature/setting/navigation/SettingNavigation.kt
@@ -5,23 +5,21 @@ import androidx.compose.animation.core.tween
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.goalpanzi.mission_mate.core.navigation.RouteModel
+import com.goalpanzi.mission_mate.core.navigation.SettingRouteModel
 import com.goalpanzi.mission_mate.feature.setting.screen.SettingRoute
 import com.goalpanzi.mission_mate.feature.setting.screen.WebViewScreen
 
 fun NavController.navigateToSetting() {
-    this.navigate("RouteModel.Setting")
-}
-
-fun NavController.navigateToInquiry() {
-    this.navigate("SettingRouteModel.Inquiry")
+    this.navigate(RouteModel.Setting)
 }
 
 fun NavController.navigateToServicePolicy() {
-    this.navigate("SettingRouteModel.ServicePolicy")
+    this.navigate(SettingRouteModel.ServicePolicy)
 }
 
 fun NavController.navigateToPrivacyPolicy() {
-    this.navigate("SettingRouteModel.PrivacyPolicy")
+    this.navigate(SettingRouteModel.PrivacyPolicy)
 }
 
 fun NavGraphBuilder.settingNavGraph(
@@ -31,7 +29,7 @@ fun NavGraphBuilder.settingNavGraph(
     onClickPrivacyPolicy: () -> Unit,
     onClickLogout: () -> Unit
 ) {
-    composable("RouteModel.Setting",
+    composable<RouteModel.Setting>(
         enterTransition = {
             slideIntoContainer(
                 towards = AnimatedContentTransitionScope.SlideDirection.Start,
@@ -54,7 +52,7 @@ fun NavGraphBuilder.settingNavGraph(
 fun NavGraphBuilder.servicePolicyNavGraph(
     onBackClick: () -> Unit
 ) {
-    composable("SettingRouteModel.ServicePolicy") {
+    composable<SettingRouteModel.ServicePolicy> {
         WebViewScreen(
             onBackClick = onBackClick,
             url = "https://missionmate.notion.site/f638866edeaf45b58ef63d1000f30c15?pvs=73"
@@ -65,7 +63,7 @@ fun NavGraphBuilder.servicePolicyNavGraph(
 fun NavGraphBuilder.privacyPolicyNavGraph(
     onBackClick: () -> Unit
 ) {
-    composable("SettingRouteModel.PrivacyPolicy") {
+    composable<SettingRouteModel.PrivacyPolicy> {
         WebViewScreen(
             onBackClick = onBackClick,
             url = "https://missionmate.notion.site/c79e9e6990de466490c584f351b364b7?pvs=4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ androidxActivity = "1.9.1"
 
 ## Compose
 composeBom = "2024.06.00"
-navigation-compose = "2.7.7"
+navigation-compose = "2.8.5"
 composeMaterial = "1.7.0"
 
 ## Kotlin Symbol Processing (KSP)


### PR DESCRIPTION
## 주요 내용
- androidx.navigation:navigation-compose 버전을 2.8.5으로 올리면서 String으로 되어있던 route들을 RouteModel등의 클래스로 수정
- ViewModel 인수 전달은 savedStateHandle.toRoute 을 통해 전달
- RouteModel 에 MainTabRoute를 정의하였습니다. 이번 PR과 무관한 내용일 수 있지만 RouteModel을 수정하면서 HistoryRouteModel을 비롯한 MainTabRoute를 정리하였습니다.