### PR TITLE
사용자 인증 기록화면을 스크롤 가능하도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ proguard/
 # Log Files
 
 # Android Studio
-/build
 /*/build/
 /*/local.properties
 /*/out
@@ -91,6 +90,7 @@ obj/
 /out/
 
 # User-specific configurations
+.idea/
 .idea/caches/
 .idea/libraries/
 .idea/shelf/

--- a/build-logic/src/main/kotlin/missionmate.android.feature.gradle.kts
+++ b/build-logic/src/main/kotlin/missionmate.android.feature.gradle.kts
@@ -1,5 +1,4 @@
 import com.goalpanzi.mission_mate.convention.configureHiltAndroid
-import com.goalpanzi.mission_mate.convention.libs
 
 plugins {
     id("missionmate.android.library")

--- a/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/mission/di/MissionDataModule.kt
+++ b/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/mission/di/MissionDataModule.kt
@@ -13,5 +13,4 @@ internal abstract class MissionDataModule {
 
     @Binds
     abstract fun bindMissionRepository(impl: MissionRepositoryImpl): MissionRepository
-
 }

--- a/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/mission/mapper/UserStoryMapper.kt
+++ b/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/mission/mapper/UserStoryMapper.kt
@@ -1,0 +1,14 @@
+package com.goalpanzi.mission_mate.core.mission.mapper
+
+import com.goalpanzi.mission_mate.core.data.common.mapper.toModel
+import com.goalpanzi.mission_mate.core.domain.mission.model.VerificationInfoByBlockNumber
+import com.goalpanzi.mission_mate.core.network.model.response.VerificationInfoByBlockNumberResponse
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+fun VerificationInfoByBlockNumberResponse.toModel() = VerificationInfoByBlockNumber(
+    nickname = nickname,
+    characterType = characterType.toModel(),
+    imageUrl = imageUrl,
+    verifiedAt = LocalDateTime.parse(verifiedAt, DateTimeFormatter.ISO_DATE_TIME).toLocalDate()
+)

--- a/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/mission/repository/MissionRepositoryImpl.kt
+++ b/core/data/mission/src/main/java/com/goalpanzi/mission_mate/core/mission/repository/MissionRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.goalpanzi.mission_mate.core.domain.mission.model.MissionDetail
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionRank
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerification
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerifications
+import com.goalpanzi.mission_mate.core.domain.mission.model.VerificationInfoByBlockNumber
 import com.goalpanzi.mission_mate.core.domain.mission.repository.MissionRepository
 import com.goalpanzi.mission_mate.core.network.model.request.CompleteMissionRequest
 import com.goalpanzi.mission_mate.core.network.model.request.MissionVerificationsViewRequest
@@ -73,7 +74,7 @@ class MissionRepositoryImpl @Inject constructor(
     override suspend fun getMyMissionVerification(
         missionId: Long,
         number: Int
-    ): DomainResult<MissionVerification> = handleResult {
+    ): DomainResult<VerificationInfoByBlockNumber> = handleResult {
         missionService.getMyMissionVerification(missionId, number)
     }.convert {
         it.toModel()

--- a/core/data/user/src/main/java/com/goalpanzi/mission_mate/core/data/user/di/UserDataModule.kt
+++ b/core/data/user/src/main/java/com/goalpanzi/mission_mate/core/data/user/di/UserDataModule.kt
@@ -12,5 +12,4 @@ import dagger.hilt.components.SingletonComponent
 internal abstract class UserDataModule {
     @Binds
     abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
-
 }

--- a/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/model/VerificationInfoByBlockNumber.kt
+++ b/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/model/VerificationInfoByBlockNumber.kt
@@ -1,0 +1,11 @@
+package com.goalpanzi.mission_mate.core.domain.mission.model
+
+import com.goalpanzi.mission_mate.core.domain.common.model.user.CharacterType
+import java.time.LocalDate
+
+data class VerificationInfoByBlockNumber(
+    val nickname: String,
+    val characterType: CharacterType,
+    val imageUrl: String,
+    val verifiedAt: LocalDate
+)

--- a/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/repository/MissionRepository.kt
+++ b/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/repository/MissionRepository.kt
@@ -6,6 +6,7 @@ import com.goalpanzi.mission_mate.core.domain.mission.model.MissionDetail
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionRank
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerification
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerifications
+import com.goalpanzi.mission_mate.core.domain.mission.model.VerificationInfoByBlockNumber
 import kotlinx.coroutines.flow.Flow
 import java.io.File
 
@@ -22,7 +23,7 @@ interface MissionRepository  {
 
     suspend fun verifyMission(missionId: Long, image: File) : DomainResult<Unit>
 
-    suspend fun getMyMissionVerification(missionId: Long, number : Int) : DomainResult<MissionVerification>
+    suspend fun getMyMissionVerification(missionId: Long, number : Int) : DomainResult<VerificationInfoByBlockNumber>
 
     suspend fun completeMission(missionId : Long) : DomainResult<Unit>
 

--- a/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/usecase/GetMyMissionVerificationUseCase.kt
+++ b/core/domain/mission/src/main/java/com/goalpanzi/mission_mate/core/domain/mission/usecase/GetMyMissionVerificationUseCase.kt
@@ -2,6 +2,7 @@ package com.goalpanzi.mission_mate.core.domain.mission.usecase
 
 import com.goalpanzi.mission_mate.core.domain.common.DomainResult
 import com.goalpanzi.mission_mate.core.domain.mission.model.MissionVerification
+import com.goalpanzi.mission_mate.core.domain.mission.model.VerificationInfoByBlockNumber
 import com.goalpanzi.mission_mate.core.domain.mission.repository.MissionRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -13,7 +14,7 @@ class GetMyMissionVerificationUseCase @Inject constructor(
     operator fun invoke(
         missionId: Long,
         number : Int
-    ): Flow<DomainResult<MissionVerification>> = flow {
+    ): Flow<DomainResult<VerificationInfoByBlockNumber>> = flow {
         emit(missionRepository.getMyMissionVerification(missionId,number))
     }
 }

--- a/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/model/RouteModel.kt
+++ b/core/navigation/src/main/java/com/goalpanzi/mission_mate/core/navigation/model/RouteModel.kt
@@ -47,15 +47,19 @@ sealed interface RouteModel {
             @Serializable
             data class UserStory(
                 val userCharacter : String,
-                val nickname : String,
-                val verifiedAt : String,
-                val imageUrl : String
             ) : MissionRouteModel
 
             @Serializable
             data class VerificationPreview(
                 val missionId : Long,
                 val imageUrl : String
+            ) : MissionRouteModel
+
+            @Serializable
+            data class MyVerificationHistory(
+                val missionId : Long,
+                val number: Int,
+                val count: Int,
             ) : MissionRouteModel
         }
 

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/response/VerificationInfoByBlockNumberResponse.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/model/response/VerificationInfoByBlockNumberResponse.kt
@@ -1,0 +1,13 @@
+package com.goalpanzi.mission_mate.core.network.model.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VerificationInfoByBlockNumberResponse(
+    val nickname: String,
+    val characterType: CharacterTypeResponse,
+    val missionVerificationId: Long,
+    val imageUrl: String,
+    val verifiedAt: String,
+    val viewedAt: String
+)

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/service/MissionService.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/service/MissionService.kt
@@ -7,6 +7,7 @@ import com.goalpanzi.mission_mate.core.network.model.response.MissionDetailRespo
 import com.goalpanzi.mission_mate.core.network.model.response.MissionRankResponse
 import com.goalpanzi.mission_mate.core.network.model.response.MissionVerificationResponse
 import com.goalpanzi.mission_mate.core.network.model.response.MissionVerificationsResponse
+import com.goalpanzi.mission_mate.core.network.model.response.VerificationInfoByBlockNumberResponse
 import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
@@ -61,7 +62,7 @@ interface MissionService {
     suspend fun getMyMissionVerification(
         @Path("missionId") missionId: Long,
         @Path("number") number: Int
-    ) : Response<MissionVerificationResponse>
+    ) : Response<VerificationInfoByBlockNumberResponse>
 
     @POST("/api/mission-members/complete")
     suspend fun completeMission(

--- a/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/service/UserStoryService.kt
+++ b/core/network/src/main/java/com/goalpanzi/mission_mate/core/network/service/UserStoryService.kt
@@ -1,0 +1,15 @@
+package com.goalpanzi.mission_mate.core.network.service
+
+import com.goalpanzi.mission_mate.core.network.model.response.VerificationInfoByBlockNumberResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface UserStoryService {
+
+    @GET("/api/missions/{missionId}/verifications/me/{number}")
+    suspend fun getVerificationInfoByBlockNumber(
+        @Path("missionId") missionId: Long,
+        @Path("number") number: Int,
+    ) : Response<VerificationInfoByBlockNumberResponse>
+}

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/BoardNavigation.kt
@@ -7,17 +7,19 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.goalpanzi.mission_mate.core.navigation.model.RouteModel.MainTabRoute.MissionRouteModel
-import com.goalpanzi.mission_mate.core.ui.util.slideInFromEnd
 import com.goalpanzi.mission_mate.core.ui.util.slideInFromBottom
+import com.goalpanzi.mission_mate.core.ui.util.slideInFromEnd
 import com.goalpanzi.mission_mate.core.ui.util.slideOutToBottom
 import com.goalpanzi.mission_mate.core.ui.util.slideOutToEnd
 import com.goalpanzi.mission_mate.feature.board.model.CharacterUiModel
+import com.goalpanzi.mission_mate.feature.board.verification.model.MyVerificationExtra
 import com.goalpanzi.mission_mate.feature.board.model.UserStory
 import com.goalpanzi.mission_mate.feature.board.screen.BoardFinishRoute
 import com.goalpanzi.mission_mate.feature.board.screen.BoardMissionDetailRoute
 import com.goalpanzi.mission_mate.feature.board.screen.BoardRoute
 import com.goalpanzi.mission_mate.feature.board.screen.UserStoryScreen
-import com.goalpanzi.mission_mate.feature.board.screen.VerificationPreviewRoute
+import com.goalpanzi.mission_mate.feature.board.verification.screen.MyVerificationHistoryScreen
+import com.goalpanzi.mission_mate.feature.board.verification.screen.VerificationPreviewRoute
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -37,7 +39,8 @@ fun NavGraphBuilder.boardNavGraph(
     onNavigateDetail : (Long) -> Unit,
     onNavigateFinish : (Long) -> Unit,
     onNavigateStory: (UserStory) -> Unit,
-    onNavigateToPreview: (Long, Uri) -> Unit
+    onNavigateToPreview: (Long, Uri) -> Unit,
+    onNavigateMyVerificationHistory: (MyVerificationExtra) -> Unit
 ) {
     composable<MissionRouteModel.Board> { navBackStackEntry ->
         BoardRoute(
@@ -46,6 +49,7 @@ fun NavGraphBuilder.boardNavGraph(
             onNavigateFinish = onNavigateFinish,
             onClickStory = onNavigateStory,
             onPreviewImage = onNavigateToPreview,
+            onNavigateMyVerificationHistory = onNavigateMyVerificationHistory
         )
     }
 }
@@ -92,16 +96,12 @@ fun NavGraphBuilder.boardFinishNavGraph(
 }
 
 fun NavController.navigateToUserStory(
-    userStory: UserStory
-) = with(userStory) {
-    val encodedUrl = URLEncoder.encode(imageUrl, StandardCharsets.UTF_8.toString())
+    character: CharacterUiModel
+) {
     this@navigateToUserStory
         .navigate(
             MissionRouteModel.UserStory(
-                userCharacter = characterUiModelType.name.uppercase(),
-                nickname = nickname,
-                verifiedAt = verifiedAt,
-                imageUrl = encodedUrl
+                userCharacter = character.name.uppercase()
             )
         )
 }
@@ -121,9 +121,6 @@ fun NavGraphBuilder.userStoryNavGraph(
             val characterUiModel = userCharacter.let { CharacterUiModel.valueOf(it) }
             UserStoryScreen(
                 characterUiModel = characterUiModel,
-                nickname = nickname,
-                verifiedAt = verifiedAt,
-                imageUrl = imageUrl,
                 onClickClose = onClickClose
             )
         }
@@ -153,6 +150,20 @@ fun NavGraphBuilder.verificationPreviewNavGraph(
         VerificationPreviewRoute(
             onClickClose = onClickClose,
             onUploadSuccess = { onUploadSuccess() }
+        )
+    }
+}
+
+fun NavController.navigateToMyVerificationHistory(extra: MyVerificationExtra) {
+    this.navigate(extra.toRouteModel())
+}
+
+fun NavGraphBuilder.myVerificationHistoryNavGraph(
+    onClickClose: () -> Unit
+) {
+    composable<MissionRouteModel.MyVerificationHistory> {
+        MyVerificationHistoryScreen(
+            onClickClose = onClickClose
         )
     }
 }

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/UserStoryEntry.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/UserStoryEntry.kt
@@ -1,0 +1,7 @@
+package com.goalpanzi.mission_mate.feature.board.model
+
+data class UserStoryEntry(
+    val missionId: Long,
+    val characterUiModel: CharacterUiModel,
+    val position: Int
+)

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/uimodel/UserStoryUiModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/model/uimodel/UserStoryUiModel.kt
@@ -1,0 +1,11 @@
+package com.goalpanzi.mission_mate.feature.board.model.uimodel
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+
+@Stable
+sealed interface UserStoryUiModel {
+    data object Loading : UserStoryUiModel
+
+
+}

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/BoardScreen.kt
@@ -33,26 +33,27 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.goalpanzi.mission_mate.core.designsystem.component.StableImage
 import com.goalpanzi.mission_mate.core.designsystem.theme.ColorWhite_FFFFFFFF
 import com.goalpanzi.mission_mate.core.domain.mission.model.BoardReward
 import com.goalpanzi.mission_mate.feature.board.R
 import com.goalpanzi.mission_mate.feature.board.component.Board
 import com.goalpanzi.mission_mate.feature.board.component.BoardBottomView
 import com.goalpanzi.mission_mate.feature.board.component.BoardTopView
-import com.goalpanzi.mission_mate.feature.board.component.dialog.InvitationCodeDialog
 import com.goalpanzi.mission_mate.feature.board.component.dialog.BoardEventDialog
 import com.goalpanzi.mission_mate.feature.board.component.dialog.DeleteMissionDialog
+import com.goalpanzi.mission_mate.feature.board.component.dialog.InvalidMissionErrorDialog
+import com.goalpanzi.mission_mate.feature.board.component.dialog.InvitationCodeDialog
 import com.goalpanzi.mission_mate.feature.board.model.BoardPiece
+import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import com.goalpanzi.mission_mate.feature.board.model.MissionState
+import com.goalpanzi.mission_mate.feature.board.verification.model.MyVerificationExtra
 import com.goalpanzi.mission_mate.feature.board.model.UserStory
 import com.goalpanzi.mission_mate.feature.board.model.toCharacterUiModel
 import com.goalpanzi.mission_mate.feature.board.model.toUserStory
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionBoardUiModel
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionUiModel
 import com.goalpanzi.mission_mate.feature.board.model.uimodel.MissionVerificationUiModel
-import com.goalpanzi.mission_mate.core.designsystem.component.StableImage
-import com.goalpanzi.mission_mate.feature.board.component.dialog.InvalidMissionErrorDialog
-import com.goalpanzi.mission_mate.feature.board.model.MissionError
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -63,6 +64,7 @@ fun BoardRoute(
     onNavigateDetail: (Long) -> Unit,
     onNavigateFinish : (Long) -> Unit,
     onClickStory: (UserStory) -> Unit,
+    onNavigateMyVerificationHistory: (MyVerificationExtra) -> Unit,
     onPreviewImage: (Long, Uri) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: BoardViewModel = hiltViewModel()
@@ -120,7 +122,7 @@ fun BoardRoute(
         }
         launch {
             viewModel.myMissionVerification.collect {
-                onClickStory(it)
+                onNavigateMyVerificationHistory(it)
             }
         }
         launch {
@@ -228,7 +230,7 @@ fun BoardRoute(
             }
         },
         onClickMyVerificationBoardBlock = {
-            viewModel.getMyMissionVerification(it)
+            viewModel.navigateToVerificationHistory(it)
         }
     )
 

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/UserStroyScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/screen/UserStroyScreen.kt
@@ -1,6 +1,5 @@
 package com.goalpanzi.mission_mate.feature.board.screen
 
-import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/model/MyVerificationExtra.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/model/MyVerificationExtra.kt
@@ -1,0 +1,15 @@
+package com.goalpanzi.mission_mate.feature.board.verification.model
+
+import com.goalpanzi.mission_mate.core.navigation.model.RouteModel.MainTabRoute.MissionRouteModel
+
+data class MyVerificationExtra(
+    val missionId: Long,
+    val number: Int,
+    val count: Int
+) {
+    fun toRouteModel() = MissionRouteModel.MyVerificationHistory(
+        missionId = missionId,
+        number = number,
+        count = count
+    )
+}

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/model/VerificationUiState.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/model/VerificationUiState.kt
@@ -1,0 +1,26 @@
+package com.goalpanzi.mission_mate.feature.board.verification.model
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import com.goalpanzi.mission_mate.core.domain.common.model.user.CharacterType
+
+@Immutable
+data class VerificationUiState(
+    val nickname: String,
+    val characterType: CharacterType?,
+    val items: List<VerificationItemState>,
+    val position: Int
+) {
+    @Stable
+    sealed interface VerificationItemState {
+
+        @Immutable
+        data object Loading : VerificationItemState
+
+        @Immutable
+        data class Success(
+            val verifiedAt: String,
+            val image: String
+        ) : VerificationItemState
+    }
+}

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/screen/MyVerificationHistoryScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/screen/MyVerificationHistoryScreen.kt
@@ -1,0 +1,243 @@
+package com.goalpanzi.mission_mate.feature.board.verification.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.paint
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.goalpanzi.mission_mate.core.designsystem.component.StableImage
+import com.goalpanzi.mission_mate.core.designsystem.ext.clickableWithoutRipple
+import com.goalpanzi.mission_mate.core.designsystem.theme.ColorBlack_FF000000
+import com.goalpanzi.mission_mate.core.designsystem.theme.ColorWhite_FFFFFFFF
+import com.goalpanzi.mission_mate.core.designsystem.theme.MissionMateTypography
+import com.goalpanzi.mission_mate.feature.board.model.CharacterUiModel
+import com.goalpanzi.mission_mate.feature.board.model.toCharacterUiModel
+import com.goalpanzi.mission_mate.feature.board.verification.model.VerificationUiState
+import kotlinx.coroutines.flow.collectLatest
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+@Composable
+fun MyVerificationHistoryScreen(
+    modifier: Modifier = Modifier,
+    viewModel: MyVerificationHistoryViewModel = hiltViewModel(),
+    onClickClose: () -> Unit
+) {
+    val state by viewModel.verification.collectAsState()
+    val initialPosition = remember { state.position }
+    var isVisibleSpacer by remember { mutableStateOf(true) }
+
+    Box(
+        modifier = modifier.fillMaxSize()
+    ) {
+        HistoryHorizontalPager(
+            modifier = modifier,
+            initialPosition = initialPosition,
+            items = state.items,
+            onTouchEvent = { isVisibleSpacer = !isVisibleSpacer },
+            onMoveNextPosition = { viewModel.onMoveNextPosition() },
+            onMovePrevPosition = { viewModel.onMovePreviousPosition() }
+        )
+    }
+
+    if (isVisibleSpacer) {
+        VerificationHeader(
+            modifier = modifier,
+            characterUiModel = state.characterType?.toCharacterUiModel() ?: CharacterUiModel.RABBIT,
+            nickname = state.nickname,
+            verifiedAt = (state.items[state.position] as? VerificationUiState.VerificationItemState.Success)?.verifiedAt ?: "",
+            onClickClose = onClickClose
+        )
+    }
+}
+
+@Composable
+private fun HistoryHorizontalPager(
+    modifier: Modifier = Modifier,
+    initialPosition: Int,
+    items: List<VerificationUiState.VerificationItemState>,
+    onTouchEvent: () -> Unit = {},
+    onMoveNextPosition: () -> Unit = {},
+    onMovePrevPosition: () -> Unit = {}
+) {
+    val pagerState = rememberPagerState(initialPage = initialPosition) { items.size }
+
+    LaunchedEffect(pagerState) {
+        var prevPosition = pagerState.currentPage
+        snapshotFlow { pagerState.currentPage }.collectLatest { currentPosition ->
+            when {
+                prevPosition < currentPosition -> onMoveNextPosition()
+                prevPosition > currentPosition -> onMovePrevPosition()
+                else -> Unit
+            }
+            prevPosition = currentPosition
+        }
+    }
+
+    HorizontalPager(
+        modifier = modifier.fillMaxSize(),
+        state = pagerState
+    ) { position ->
+        when (items[position]) {
+            is VerificationUiState.VerificationItemState.Loading -> {
+                LoadingScreen(modifier = modifier)
+            }
+            is VerificationUiState.VerificationItemState.Success -> {
+                StoryImageViewer(
+                    imageUrl = (items[position] as VerificationUiState.VerificationItemState.Success).image,
+                    onTouchEvent = { onTouchEvent() }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StoryImageViewer(
+    imageUrl: String,
+    onTouchEvent: () -> Unit = {}
+) {
+    AsyncImage(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(URLDecoder.decode(imageUrl, StandardCharsets.UTF_8.toString()))
+            .build(),
+        contentDescription = null,
+        modifier = Modifier
+            .fillMaxSize()
+            .clickableWithoutRipple {
+                onTouchEvent()
+            },
+        contentScale = ContentScale.Fit,
+        filterQuality = FilterQuality.None
+    )
+}
+
+@Composable
+private fun VerificationHeader(
+    modifier: Modifier = Modifier,
+    characterUiModel: CharacterUiModel,
+    nickname: String,
+    verifiedAt: String,
+    onClickClose: () -> Unit
+) {
+    val statusBarPaddingValue = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+
+    Spacer(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(statusBarPaddingValue + 80.dp)
+            .background(ColorBlack_FF000000.copy(alpha = 0.7f))
+    )
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .height(93.dp)
+            .padding(horizontal = 24.dp, vertical = 14.dp)
+    ) {
+        StableImage(
+            modifier = modifier
+                .padding(top = 6.dp)
+                .size(28.dp)
+                .border(1.dp, ColorWhite_FFFFFFFF, CircleShape)
+                .paint(
+                    painter = painterResource(characterUiModel.backgroundId),
+                    contentScale = ContentScale.FillWidth
+                )
+                .padding(5.dp),
+            drawableResId = characterUiModel.imageId,
+            description = ""
+        )
+        Text(
+            text = nickname,
+            style = MissionMateTypography.body_xl_bold,
+            color = ColorWhite_FFFFFFFF,
+            modifier = modifier
+                .padding(start = 8.dp)
+                .wrapContentWidth()
+                .padding(top = 6.dp)
+        )
+
+        Text(
+            text = verifiedAt,
+            style = MissionMateTypography.body_xl_regular,
+            color = ColorWhite_FFFFFFFF,
+            modifier = modifier
+                .padding(start = 8.dp)
+                .weight(1f)
+                .padding(top = 6.dp)
+        )
+
+        IconButton(
+            onClick = {
+                onClickClose()
+            },
+            modifier = modifier.wrapContentSize()
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(id = com.goalpanzi.mission_mate.core.designsystem.R.drawable.ic_close),
+                contentDescription = "",
+                tint = ColorWhite_FFFFFFFF
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingScreen(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Transparent)
+            .focusable()
+            .clickable {}
+    ) {
+        CircularProgressIndicator(
+            modifier = modifier.align(Alignment.Center)
+        )
+    }
+}

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/screen/MyVerificationHistoryViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/screen/MyVerificationHistoryViewModel.kt
@@ -1,0 +1,76 @@
+package com.goalpanzi.mission_mate.feature.board.verification.screen
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.goalpanzi.mission_mate.core.domain.common.DomainResult
+import com.goalpanzi.mission_mate.core.domain.mission.usecase.GetMyMissionVerificationUseCase
+import com.goalpanzi.mission_mate.core.navigation.model.RouteModel.MainTabRoute.MissionRouteModel
+import com.goalpanzi.mission_mate.feature.board.verification.model.VerificationUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.stateIn
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+@HiltViewModel
+class MyVerificationHistoryViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getMyMissionVerificationUseCase: GetMyMissionVerificationUseCase
+) : ViewModel() {
+
+    private val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+
+    private val missionId = savedStateHandle.toRoute<MissionRouteModel.MyVerificationHistory>().missionId
+    private val number = savedStateHandle.toRoute<MissionRouteModel.MyVerificationHistory>().number
+    private val totalNumber = savedStateHandle.toRoute<MissionRouteModel.MyVerificationHistory>().count
+
+    private val _position = MutableStateFlow(number)
+
+    val verification: StateFlow<VerificationUiState> = _position
+        .mapNotNull { position ->
+            onMoveToPosition(position)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = VerificationUiState(
+                nickname = "",
+                characterType = null,
+                items = List<VerificationUiState.VerificationItemState>(totalNumber) { VerificationUiState.VerificationItemState.Loading },
+                position = _position.value
+            )
+        )
+
+    fun onMoveNextPosition() = _position.value++
+
+    fun onMovePreviousPosition() = _position.value--
+
+    private suspend fun onMoveToPosition(position: Int): VerificationUiState? {
+        val items = verification.value.items.takeIf { it[position] is VerificationUiState.VerificationItemState.Loading }?.toMutableList() ?: return null
+        val result = getMyMissionVerificationUseCase(missionId, position).first() as? DomainResult.Success
+        return result?.data?.run {
+            VerificationUiState(
+                nickname = nickname,
+                characterType = characterType,
+                items = items.apply {
+                    set(
+                        position, VerificationUiState.VerificationItemState.Success(
+                            verifiedAt = verifiedAt.format(formatter),
+                            image = imageUrl
+                        )
+                    )
+                },
+                position = position
+            )
+        }
+    }
+}

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/screen/VerificationPreviewScreen.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/screen/VerificationPreviewScreen.kt
@@ -1,8 +1,7 @@
-package com.goalpanzi.mission_mate.feature.board.screen
+package com.goalpanzi.mission_mate.feature.board.verification.screen
 
 import android.content.Context
 import android.net.Uri
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable

--- a/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/screen/VerificationPreviewViewModel.kt
+++ b/feature/board/src/main/java/com/goalpanzi/mission_mate/feature/board/verification/screen/VerificationPreviewViewModel.kt
@@ -1,4 +1,4 @@
-package com.goalpanzi.mission_mate.feature.board.screen
+package com.goalpanzi.mission_mate.feature.board.verification.screen
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavHost.kt
@@ -26,6 +26,7 @@ import com.goalpanzi.mission_mate.feature.board.verificationPreviewNavGraph
 import com.goalpanzi.mission_mate.feature.login.loginNavGraph
 import com.goalpanzi.mission_mate.feature.main.ext.isDarkStatusBarScreen
 import com.goalpanzi.mission_mate.core.navigation.model.MainTabDataModelType
+import com.goalpanzi.mission_mate.feature.board.myVerificationHistoryNavGraph
 import com.goalpanzi.mission_mate.feature.onboarding.boardSetupNavGraph
 import com.goalpanzi.mission_mate.feature.onboarding.boardSetupSuccessNavGraph
 import com.goalpanzi.mission_mate.feature.onboarding.invitationCodeNavGraph
@@ -124,6 +125,11 @@ internal fun MainNavHost(
                     navigator.popBackStack()
                 },
                 onUploadSuccess = {
+                    navigator.popBackStack()
+                }
+            )
+            myVerificationHistoryNavGraph(
+                onClickClose = {
                     navigator.popBackStack()
                 }
             )

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavigator.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainNavigator.kt
@@ -8,9 +8,11 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.goalpanzi.mission_mate.core.navigation.model.MainTabDataModel
 import com.goalpanzi.mission_mate.core.navigation.model.RouteModel
+import com.goalpanzi.mission_mate.feature.board.verification.model.MyVerificationExtra
 import com.goalpanzi.mission_mate.feature.board.model.UserStory
 import com.goalpanzi.mission_mate.feature.board.navigateToBoardDetail
 import com.goalpanzi.mission_mate.feature.board.navigateToBoardFinish
+import com.goalpanzi.mission_mate.feature.board.navigateToMyVerificationHistory
 import com.goalpanzi.mission_mate.feature.board.navigateToUserStory
 import com.goalpanzi.mission_mate.feature.board.navigateToVerificationPreview
 import com.goalpanzi.mission_mate.feature.login.navigateToLogin
@@ -85,11 +87,15 @@ class MainNavigator(
     }
 
     fun navigationToUserStory(userStory: UserStory) {
-        navController.navigateToUserStory(userStory)
+        navController.navigateToUserStory(userStory.characterUiModelType)
     }
 
     fun navigationToVerificationPreview(missionId: Long, imageUrl : Uri) {
         navController.navigateToVerificationPreview(missionId, imageUrl)
+    }
+
+    fun navigationToMyVerification(extra: MyVerificationExtra) {
+        navController.navigateToMyVerificationHistory(extra)
     }
 }
 

--- a/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainTabNavHost.kt
+++ b/feature/main/src/main/java/com/goalpanzi/mission_mate/feature/main/component/MainTabNavHost.kt
@@ -50,6 +50,9 @@ fun MainTabNavHost(
             },
             onNavigateToPreview = { missionId, imageUrl ->
                 mainNavigator.navigationToVerificationPreview(missionId, imageUrl)
+            },
+            onNavigateMyVerificationHistory = { extra ->
+                mainNavigator.navigationToMyVerification(extra)
             }
         )
         historyNavGraph()


### PR DESCRIPTION
## 기능 설명
진행중인 미션에서 Mission Board를 클릭하여 verification history를 확인하는 화면을 스크롤 가능한 HorizontalPager로 전환합니다.

## 변경사항
- `/api/missions/{missionId}/verifications/me/{number}` 사용하여 페이지를 넘길 때마다 해당 기록의 number를 파라미터로 api를 호출해서 사진을 가져와 그리도록 구현했습니다
- 기존 UserStory 화면을 제거하고 싶었지만, story쪽과 겹쳐 변경사항이 더 많아지고 복잡해져서 VerificationHistoryScreen을 새로 만들어 구현했습니다