### PR TITLE
1.2.0 - 내기록 화면에서 불필요한 clickable 효과를 제거합니다.

### DIFF
--- a/feature/history/src/main/java/com/goalpanzi/mission_mate/feature/history/component/HistoryList.kt
+++ b/feature/history/src/main/java/com/goalpanzi/mission_mate/feature/history/component/HistoryList.kt
@@ -176,9 +176,6 @@ fun HistoryListItem(
             .background(
                 color = ColorWhite_FFFFFFFF
             )
-            .clickable {
-                onClick()
-            }
     ) {
         if(imageUrls.isNotEmpty()){
             HistoryListItemImage(


### PR DESCRIPTION
## 주요 내용
- 내기록 아이템에서 아직 클릭 액션이 없는데 clickable 효과가 있는게 부자연스러워서 제거하였습니다.